### PR TITLE
[Phase 2] exceptions.py — custom exception hierarchy

### DIFF
--- a/psxdata/exceptions.py
+++ b/psxdata/exceptions.py
@@ -1,0 +1,55 @@
+"""Custom exception hierarchy for psxdata.
+
+All library exceptions inherit from PSXDataError, allowing callers to catch
+any library error with a single except clause.
+"""
+
+
+class PSXDataError(Exception):
+    """Base exception for all psxdata library errors."""
+
+
+class PSXUnavailableError(PSXDataError):
+    """PSX server is unreachable or returned a 5xx response."""
+
+
+class PSXConnectionError(PSXUnavailableError):
+    """Network-level failure — DNS resolution failed, connection refused, or timeout.
+
+    The server was never reached.
+    """
+
+
+class PSXServerError(PSXUnavailableError):
+    """PSX server was reached but returned a 5xx HTTP response."""
+
+
+class PSXAuthError(PSXDataError):
+    """PSX returned 401 or 403 — authentication or authorisation failure."""
+
+
+class PSXRateLimitError(PSXDataError):
+    """PSX returned 429 — rate limit exceeded."""
+
+
+class PSXParseError(PSXDataError):
+    """HTML structure changed or response could not be parsed.
+
+    Also raised for unexpected 4xx responses (400, 404, etc.).
+    """
+
+
+class InvalidSymbolError(PSXDataError):
+    """The requested ticker symbol does not exist on PSX."""
+
+
+class DelistedSymbolError(InvalidSymbolError):
+    """The requested ticker existed on PSX but has since been delisted."""
+
+
+class DataNotAvailableError(PSXDataError):
+    """Valid symbol requested but PSX returned no data for the given period."""
+
+
+class CacheError(PSXDataError):
+    """Disk cache read or write failure."""

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,58 @@
+"""Smoke tests for psxdata exception hierarchy."""
+import pytest
+from psxdata.exceptions import (
+    PSXDataError,
+    PSXUnavailableError,
+    PSXConnectionError,
+    PSXServerError,
+    PSXAuthError,
+    PSXRateLimitError,
+    PSXParseError,
+    InvalidSymbolError,
+    DelistedSymbolError,
+    DataNotAvailableError,
+    CacheError,
+)
+
+
+def test_all_exceptions_importable():
+    assert PSXDataError is not None
+
+
+def test_hierarchy_base():
+    assert issubclass(PSXUnavailableError, PSXDataError)
+    assert issubclass(PSXConnectionError, PSXUnavailableError)
+    assert issubclass(PSXServerError, PSXUnavailableError)
+    assert issubclass(PSXAuthError, PSXDataError)
+    assert issubclass(PSXRateLimitError, PSXDataError)
+    assert issubclass(PSXParseError, PSXDataError)
+    assert issubclass(InvalidSymbolError, PSXDataError)
+    assert issubclass(DelistedSymbolError, InvalidSymbolError)
+    assert issubclass(DataNotAvailableError, PSXDataError)
+    assert issubclass(CacheError, PSXDataError)
+
+
+def test_catch_base_catches_all():
+    for exc_class in [
+        PSXConnectionError, PSXServerError, PSXAuthError, PSXRateLimitError,
+        PSXParseError, DelistedSymbolError, DataNotAvailableError, CacheError,
+    ]:
+        with pytest.raises(PSXDataError):
+            raise exc_class("test")
+
+
+def test_catch_unavailable_catches_subclasses():
+    with pytest.raises(PSXUnavailableError):
+        raise PSXConnectionError("connection refused")
+    with pytest.raises(PSXUnavailableError):
+        raise PSXServerError("503")
+
+
+def test_catch_invalid_symbol_catches_delisted():
+    with pytest.raises(InvalidSymbolError):
+        raise DelistedSymbolError("XXXX was delisted")
+
+
+def test_exceptions_have_messages():
+    exc = PSXUnavailableError("PSX is down")
+    assert str(exc) == "PSX is down"


### PR DESCRIPTION
## Summary

Adds the custom exception hierarchy for the `psxdata` library. All library-specific errors inherit from `PSXDataError`, allowing callers to catch any library error with a single except clause or target specific error types precisely.

## Related Issue

- Closes #13

## Type of Change

- [x] New feature

## Testing Done

- [x] `pytest tests/unit/test_exceptions.py -v` passes → 6 PASSED
- [ ] `pytest -m reliability -v` passes
- [ ] `pytest -m integration -v` passes locally (required for scraper changes)
- [ ] Manually tested against live PSX endpoint (required for scraper changes)

## Checklist

- [x] Type hints on all new public functions
- [x] Docstrings on all new public functions
- [x] No hardcoded date formats (use `parse_date_safely()`)
- [x] No fixed column position assumptions (map by `<th>` name)
- [x] `ruff check psxdata/ api/` passes
- [x] `mypy psxdata/ api/` passes
- [ ] `CHANGELOG.md` updated (if breaking change or new user-facing feature)
- [ ] New HTML fixture captured if a new PSX endpoint interaction was added