### PR TITLE
[Phase 2] utils.py — date chunker, RateLimiter, OHLC validators

### DIFF
--- a/psxdata/utils.py
+++ b/psxdata/utils.py
@@ -1,0 +1,183 @@
+"""Shared utilities for psxdata.
+
+- chunk_date_range: split a date range into fixed-size chunks
+- RateLimiter: token-bucket rate limiter with injectable clock (thread-safe)
+- validate_ohlc_dataframe: validate OHLCV DataFrame, flag/drop bad rows
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time as _time
+from collections.abc import Callable
+from datetime import date, timedelta
+from typing import Any
+
+import pandas as pd
+
+from psxdata.constants import DEFAULT_CHUNK_DAYS, MAX_REQUESTS_PER_SECOND
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Date range chunker
+# ---------------------------------------------------------------------------
+
+def chunk_date_range(
+    start: date,
+    end: date,
+    chunk_days: int = DEFAULT_CHUNK_DAYS,
+) -> list[tuple[date, date]]:
+    """Split [start, end] into non-overlapping chunks of at most chunk_days days.
+
+    The last chunk may be shorter. Future-date clamping is the caller's
+    responsibility — this function is pure date arithmetic.
+
+    Args:
+        start: First date (inclusive).
+        end: Last date (inclusive).
+        chunk_days: Maximum days per chunk. Defaults to DEFAULT_CHUNK_DAYS (365).
+
+    Returns:
+        List of (chunk_start, chunk_end) tuples covering [start, end] exactly.
+
+    Raises:
+        ValueError: If start > end.
+    """
+    if start > end:
+        raise ValueError(f"start ({start}) must be <= end ({end})")
+    chunks: list[tuple[date, date]] = []
+    current = start
+    while current <= end:
+        chunk_end = min(current + timedelta(days=chunk_days - 1), end)
+        chunks.append((current, chunk_end))
+        current = chunk_end + timedelta(days=1)
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+class RateLimiter:
+    """Thread-safe token-bucket rate limiter.
+
+    Args:
+        max_per_second: Maximum requests allowed per second.
+        time_func: Callable returning current time in seconds. Defaults to
+            time.monotonic. Inject a fake for deterministic tests.
+        sleep_func: Callable to sleep N seconds. Defaults to time.sleep.
+            Inject a fake for deterministic tests.
+
+    Usage::
+
+        limiter = RateLimiter(max_per_second=2)
+        with limiter:
+            response = session.get(url)
+    """
+
+    def __init__(
+        self,
+        max_per_second: int = MAX_REQUESTS_PER_SECOND,
+        time_func: Callable[[], float] = _time.monotonic,
+        sleep_func: Callable[[float], None] = _time.sleep,
+    ) -> None:
+        self._interval = 1.0 / max_per_second
+        self._time = time_func
+        self._sleep = sleep_func
+        self._lock = threading.Lock()
+        self._last_request: float | None = None
+
+    def __enter__(self) -> "RateLimiter":
+        with self._lock:
+            if self._last_request is not None:
+                elapsed = self._time() - self._last_request
+                deficit = self._interval - elapsed
+                if deficit > 0:
+                    self._sleep(deficit)
+            self._last_request = self._time()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# OHLC DataFrame validator
+# ---------------------------------------------------------------------------
+
+def validate_ohlc_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Validate an OHLCV DataFrame against business rules.
+
+    Adds an ``is_anomaly`` boolean column (True = flagged but retained).
+    Rows with NaN in critical columns (close, volume) or all-NaN rows are
+    dropped. All other anomalies are flagged and retained for caller inspection.
+
+    Args:
+        df: DataFrame with columns: date, open, high, low, close, volume.
+
+    Returns:
+        Cleaned DataFrame with ``is_anomaly`` column added.
+    """
+    if df.empty:
+        df = df.copy()
+        df["is_anomaly"] = pd.Series(dtype=bool)
+        return df
+
+    df = df.copy()
+    df["is_anomaly"] = False
+
+    # Drop rows with NaN in critical columns
+    critical_null = df["close"].isna() | df["volume"].isna()
+    if critical_null.any():
+        count = int(critical_null.sum())
+        logger.warning("Dropping %d row(s) with NaN in close or volume", count)
+        df = df[~critical_null].copy()
+
+    # Drop all-NaN rows (completely corrupt)
+    all_null = df.isna().all(axis=1)
+    if all_null.any():
+        logger.warning("Dropping %d completely corrupt row(s)", int(all_null.sum()))
+        df = df[~all_null].copy()
+
+    if df.empty:
+        return df
+
+    # OHLC constraint: low <= open, close <= high
+    ohlc_bad = (
+        (df["low"] > df["open"])
+        | (df["low"] > df["close"])
+        | (df["open"] > df["high"])
+        | (df["close"] > df["high"])
+    )
+    if ohlc_bad.any():
+        logger.warning("OHLC constraint violated in %d row(s) — flagged", int(ohlc_bad.sum()))
+        df.loc[ohlc_bad, "is_anomaly"] = True
+
+    # Negative volume
+    neg_vol = df["volume"] < 0
+    if neg_vol.any():
+        logger.warning("Negative volume in %d row(s) — flagged", int(neg_vol.sum()))
+        df.loc[neg_vol, "is_anomaly"] = True
+
+    # Date-based checks
+    if "date" in df.columns:
+        dates = pd.to_datetime(df["date"])
+
+        # Future dates
+        today = pd.Timestamp.now().normalize()
+        future = dates > today
+        if future.any():
+            logger.warning("Future date(s) found in %d row(s)", int(future.sum()))
+
+        # Duplicate dates
+        dupes = df["date"].duplicated(keep=False)
+        if dupes.any():
+            logger.warning("Duplicate date(s) found in %d row(s)", int(dupes.sum()))
+
+        # Non-chronological order
+        if not dates.is_monotonic_increasing:
+            logger.warning("Dates are not in chronological order")
+
+    return df

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,231 @@
+"""Unit tests for psxdata/utils.py — date chunker, RateLimiter, OHLC validator."""
+import threading
+from datetime import date, timedelta
+
+import pandas as pd
+import pytest
+
+from psxdata.utils import RateLimiter, chunk_date_range, validate_ohlc_dataframe
+
+
+# ---------------------------------------------------------------------------
+# chunk_date_range
+# ---------------------------------------------------------------------------
+
+class TestChunkDateRange:
+    def test_single_year_range(self):
+        chunks = chunk_date_range(date(2023, 1, 1), date(2023, 12, 31))
+        assert chunks == [(date(2023, 1, 1), date(2023, 12, 31))]
+
+    def test_multi_year_range(self):
+        # 3 years of 365-day chunks: 2020 is a leap year so chunks don't align
+        # to calendar year boundaries — the chunker is pure date arithmetic
+        chunks = chunk_date_range(date(2020, 1, 1), date(2022, 12, 31), chunk_days=365)
+        # First chunk: 2020-01-01 to 2020-12-30 (365 days, 2020 has 366)
+        assert chunks[0] == (date(2020, 1, 1), date(2020, 12, 30))
+        # Contiguous and covers the full range
+        assert chunks[0][0] == date(2020, 1, 1)
+        assert chunks[-1][1] == date(2022, 12, 31)
+        # All chunks are at most 365 days
+        for s, e in chunks:
+            assert (e - s).days < 365
+
+    def test_sub_year_range(self):
+        chunks = chunk_date_range(date(2024, 1, 1), date(2024, 3, 15))
+        assert chunks == [(date(2024, 1, 1), date(2024, 3, 15))]
+
+    def test_single_day(self):
+        chunks = chunk_date_range(date(2024, 6, 1), date(2024, 6, 1))
+        assert chunks == [(date(2024, 6, 1), date(2024, 6, 1))]
+
+    def test_start_gt_end_raises(self):
+        with pytest.raises(ValueError, match="start"):
+            chunk_date_range(date(2024, 12, 31), date(2024, 1, 1))
+
+    def test_chunk_does_not_overshoot_end(self):
+        chunks = chunk_date_range(date(2024, 1, 1), date(2024, 6, 30), chunk_days=365)
+        assert chunks == [(date(2024, 1, 1), date(2024, 6, 30))]
+
+    def test_chunks_are_contiguous_no_gaps(self):
+        chunks = chunk_date_range(date(2020, 1, 1), date(2022, 6, 15), chunk_days=365)
+        for i in range(len(chunks) - 1):
+            assert chunks[i][1] + timedelta(days=1) == chunks[i + 1][0]
+
+    def test_chunks_cover_full_range(self):
+        start, end = date(2020, 1, 1), date(2022, 6, 15)
+        chunks = chunk_date_range(start, end, chunk_days=365)
+        assert chunks[0][0] == start
+        assert chunks[-1][1] == end
+
+    def test_custom_chunk_days(self):
+        chunks = chunk_date_range(date(2024, 1, 1), date(2024, 3, 31), chunk_days=30)
+        assert len(chunks) == 4  # 90 days / 30 = 3 full + 1 partial
+
+
+# ---------------------------------------------------------------------------
+# RateLimiter
+# ---------------------------------------------------------------------------
+
+class TestRateLimiter:
+    def test_allows_first_request_immediately(self):
+        calls = []
+        mock_time = [0.0]
+        slept = []
+
+        def t(): return mock_time[0]
+        def s(sec): slept.append(sec); mock_time[0] += sec
+
+        limiter = RateLimiter(max_per_second=2, time_func=t, sleep_func=s)
+        with limiter:
+            calls.append(1)
+        assert calls == [1]
+        assert slept == []  # no sleep on first request
+
+    def test_enforces_rate_limit(self):
+        mock_time = [0.0]
+        slept = []
+
+        def t(): return mock_time[0]
+        def s(sec): slept.append(sec); mock_time[0] += sec
+
+        limiter = RateLimiter(max_per_second=2, time_func=t, sleep_func=s)
+        with limiter:
+            pass
+        # Second request immediately — should sleep 0.5s (1/2 req/sec interval)
+        with limiter:
+            pass
+        assert len(slept) == 1
+        assert abs(slept[0] - 0.5) < 1e-9
+
+    def test_no_sleep_when_enough_time_elapsed(self):
+        mock_time = [0.0]
+        slept = []
+
+        def t(): return mock_time[0]
+        def s(sec): slept.append(sec); mock_time[0] += sec
+
+        limiter = RateLimiter(max_per_second=2, time_func=t, sleep_func=s)
+        with limiter:
+            pass
+        mock_time[0] = 1.0  # 1 second has passed — well above 0.5s interval
+        with limiter:
+            pass
+        assert slept == []
+
+    def test_thread_safety(self):
+        """Multiple threads using the same limiter don't crash."""
+        limiter = RateLimiter(max_per_second=100)  # high limit so test is fast
+        errors = []
+
+        def use():
+            try:
+                with limiter:
+                    pass
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=use) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# validate_ohlc_dataframe
+# ---------------------------------------------------------------------------
+
+def _make_df(rows):
+    """Helper — build OHLCV DataFrame from list of dicts."""
+    return pd.DataFrame(rows)
+
+
+class TestValidateOHLCDataframe:
+    def _valid_row(self, date_str="2024-01-01"):
+        return {
+            "date": pd.Timestamp(date_str),
+            "open": 100.0,
+            "high": 110.0,
+            "low": 90.0,
+            "close": 105.0,
+            "volume": 1000,
+        }
+
+    def test_valid_dataframe_passes(self):
+        df = _make_df([self._valid_row("2024-01-01"), self._valid_row("2024-01-02")])
+        result = validate_ohlc_dataframe(df)
+        assert len(result) == 2
+        assert "is_anomaly" in result.columns
+        assert not result["is_anomaly"].any()
+
+    def test_low_gt_open_flags_row(self):
+        row = self._valid_row()
+        row["low"] = 200.0  # low > open — anomaly
+        df = _make_df([row])
+        result = validate_ohlc_dataframe(df)
+        assert len(result) == 1
+        assert bool(result.iloc[0]["is_anomaly"]) is True
+
+    def test_close_gt_high_flags_row(self):
+        row = self._valid_row()
+        row["close"] = 200.0  # close > high — anomaly
+        df = _make_df([row])
+        result = validate_ohlc_dataframe(df)
+        assert bool(result.iloc[0]["is_anomaly"]) is True
+
+    def test_negative_volume_flags_row(self):
+        row = self._valid_row()
+        row["volume"] = -1
+        df = _make_df([row])
+        result = validate_ohlc_dataframe(df)
+        assert bool(result.iloc[0]["is_anomaly"]) is True
+
+    def test_nan_close_drops_row(self):
+        row = self._valid_row()
+        row["close"] = float("nan")
+        df = _make_df([row])
+        result = validate_ohlc_dataframe(df)
+        assert len(result) == 0
+
+    def test_nan_volume_drops_row(self):
+        row = self._valid_row()
+        row["volume"] = float("nan")
+        df = _make_df([row])
+        result = validate_ohlc_dataframe(df)
+        assert len(result) == 0
+
+    def test_future_date_warns_retains_row(self, caplog):
+        import logging
+        row = self._valid_row("2099-01-01")
+        df = _make_df([row])
+        with caplog.at_level(logging.WARNING):
+            result = validate_ohlc_dataframe(df)
+        assert len(result) == 1
+        assert "future" in caplog.text.lower()
+
+    def test_duplicate_dates_warns_retains_both(self, caplog):
+        import logging
+        df = _make_df([self._valid_row("2024-01-01"), self._valid_row("2024-01-01")])
+        with caplog.at_level(logging.WARNING):
+            result = validate_ohlc_dataframe(df)
+        assert len(result) == 2
+        assert "duplicate" in caplog.text.lower()
+
+    def test_non_chronological_warns_retains(self, caplog):
+        import logging
+        df = _make_df([self._valid_row("2024-01-02"), self._valid_row("2024-01-01")])
+        with caplog.at_level(logging.WARNING):
+            result = validate_ohlc_dataframe(df)
+        assert len(result) == 2
+        assert "chronolog" in caplog.text.lower()
+
+    def test_partially_corrupt_df_clean_rows_returned(self):
+        rows = [
+            self._valid_row("2024-01-01"),
+            {**self._valid_row("2024-01-02"), "close": float("nan")},  # dropped
+            self._valid_row("2024-01-03"),
+        ]
+        df = _make_df(rows)
+        result = validate_ohlc_dataframe(df)
+        assert len(result) == 2


### PR DESCRIPTION
## Summary

Adds three independent utilities used by all Phase 3 scrapers: `chunk_date_range` (configurable date-range splitter), `RateLimiter` (thread-safe token-bucket with injectable clock for deterministic testing), and `validate_ohlc_dataframe` (flags/drops bad rows, adds `is_anomaly` column).

## Related Issue

- Closes #15

## Type of Change

- [x] New feature

## Testing Done

- [x] `pytest tests/unit/test_utils.py -v` passes → 23 PASSED
- [ ] `pytest -m reliability -v` passes
- [ ] `pytest -m integration -v` passes locally (required for scraper changes)
- [ ] Manually tested against live PSX endpoint (required for scraper changes)

## Checklist

- [x] Type hints on all new public functions
- [x] Docstrings on all new public functions
- [x] No hardcoded date formats (use `parse_date_safely()`)
- [x] No fixed column position assumptions (map by `<th>` name)
- [x] `ruff check psxdata/ api/` passes
- [x] `mypy psxdata/ api/` passes
- [ ] `CHANGELOG.md` updated (if breaking change or new user-facing feature)
- [ ] New HTML fixture captured if a new PSX endpoint interaction was added