### PR TITLE
[Phase 2] parsers/normalizers.py — date parsing and type coercion

### DIFF
--- a/psxdata/parsers/normalizers.py
+++ b/psxdata/parsers/normalizers.py
@@ -1,0 +1,89 @@
+"""Data normalisation utilities for psxdata parsers.
+
+No imports from the psxdata library — these are pure functions with no
+dependencies on scraping, caching, or models. Third-party imports
+(dateutil, datetime) are fine.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+from dateutil import parser as dateutil_parser
+
+_PSX_DATE_FORMATS = ["%b %d, %Y", "%d-%b-%Y", "%Y-%m-%d", "%d/%m/%Y"]
+
+
+def parse_date_safely(value: Any) -> datetime | None:
+    """Parse a date string using known PSX formats, falling back to fuzzy parsing.
+
+    Never raises. Returns None for any unparseable or non-string input.
+
+    Args:
+        value: The value to parse. Non-str inputs return None immediately.
+
+    Returns:
+        datetime if parseable, None otherwise.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    for fmt in _PSX_DATE_FORMATS:
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    try:
+        return dateutil_parser.parse(value, fuzzy=True)
+    except Exception:
+        return None
+
+
+def coerce_numeric(value: Any) -> float | None:
+    """Convert a raw PSX cell value to float, stripping formatting characters.
+
+    Handles commas, percent signs, currency prefixes (PKR), and whitespace.
+    Never raises. Returns None for unparseable input.
+
+    Args:
+        value: Raw cell string from PSX HTML table.
+
+    Returns:
+        float if parseable, None otherwise.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    cleaned = cleaned.replace(",", "").replace("%", "").replace("PKR", "").strip()
+    try:
+        return float(cleaned)
+    except (ValueError, TypeError):
+        return None
+
+
+def normalize_column_name(name: str) -> str:
+    """Normalize a raw PSX table header to a snake_case identifier.
+
+    Used as fallback for headers not found in constants.COLUMN_MAP.
+    Strips whitespace, lowercases, replaces spaces with underscores,
+    removes non-alphanumeric characters (except underscores).
+
+    Args:
+        name: Raw header string from a PSX <th> tag.
+
+    Returns:
+        Normalized snake_case string.
+    """
+    name = name.strip().lower()
+    name = name.replace(" ", "_")
+    name = re.sub(r"[^\w]", "_", name)
+    name = re.sub(r"_+", "_", name)
+    name = name.strip("_")
+    return name

--- a/tests/unit/test_normalizers.py
+++ b/tests/unit/test_normalizers.py
@@ -1,0 +1,104 @@
+"""Unit tests for psxdata/parsers/normalizers.py."""
+from datetime import datetime
+
+import pytest
+
+from psxdata.parsers.normalizers import coerce_numeric, normalize_column_name, parse_date_safely
+
+
+class TestParseDateSafely:
+    """parse_date_safely must never raise — always returns datetime | None."""
+
+    def test_format_b_d_Y(self):
+        assert parse_date_safely("Jan 05, 2024") == datetime(2024, 1, 5)
+
+    def test_format_d_b_Y(self):
+        assert parse_date_safely("05-Jan-2024") == datetime(2024, 1, 5)
+
+    def test_format_Y_m_d(self):
+        assert parse_date_safely("2024-01-05") == datetime(2024, 1, 5)
+
+    def test_format_d_slash_m_slash_Y(self):
+        assert parse_date_safely("05/01/2024") == datetime(2024, 1, 5)
+
+    def test_fuzzy_fallback(self):
+        result = parse_date_safely("January 5 2024")
+        assert result == datetime(2024, 1, 5)
+
+    def test_empty_string_returns_none(self):
+        assert parse_date_safely("") is None
+
+    def test_none_returns_none(self):
+        assert parse_date_safely(None) is None  # type: ignore[arg-type]
+
+    def test_int_returns_none(self):
+        assert parse_date_safely(20240105) is None  # type: ignore[arg-type]
+
+    def test_whitespace_only_returns_none(self):
+        assert parse_date_safely("   ") is None
+
+    def test_garbage_string_returns_none(self):
+        assert parse_date_safely("not a date") is None
+
+    def test_never_raises_for_any_input(self):
+        """Exhaustive check — no input should ever raise."""
+        inputs = [None, "", "   ", "abc", 12345, 3.14, [], {}, object()]
+        for val in inputs:
+            result = parse_date_safely(val)  # type: ignore[arg-type]
+            assert result is None, f"Expected None for {val!r}, got {result!r}"
+
+    def test_leading_trailing_whitespace_stripped(self):
+        assert parse_date_safely("  2024-01-05  ") == datetime(2024, 1, 5)
+
+
+class TestCoerceNumeric:
+    def test_plain_float(self):
+        assert coerce_numeric("481.99") == pytest.approx(481.99)
+
+    def test_comma_separated(self):
+        assert coerce_numeric("1,234.56") == pytest.approx(1234.56)
+
+    def test_strip_percent(self):
+        assert coerce_numeric("10.00%") == pytest.approx(10.0)
+
+    def test_strip_pkr(self):
+        assert coerce_numeric("PKR 500.00") == pytest.approx(500.0)
+
+    def test_integer_string(self):
+        assert coerce_numeric("4496408") == pytest.approx(4496408.0)
+
+    def test_none_returns_none(self):
+        assert coerce_numeric(None) is None  # type: ignore[arg-type]
+
+    def test_empty_returns_none(self):
+        assert coerce_numeric("") is None
+
+    def test_non_numeric_returns_none(self):
+        assert coerce_numeric("N/A") is None
+
+    def test_never_raises(self):
+        for val in [None, "", "abc", "N/A", object()]:
+            result = coerce_numeric(val)  # type: ignore[arg-type]
+            assert result is None
+
+
+class TestNormalizeColumnName:
+    def test_uppercase_to_lower(self):
+        assert normalize_column_name("VOLUME") == "volume"
+
+    def test_spaces_to_underscores(self):
+        assert normalize_column_name("MARKET CAP") == "market_cap"
+
+    def test_leading_trailing_whitespace(self):
+        assert normalize_column_name("  DATE  ") == "date"
+
+    def test_special_chars_removed(self):
+        result = normalize_column_name("CHANGE (%)")
+        # parens and % become underscores, then collapsed
+        assert "change" in result
+
+    def test_multiple_spaces_collapsed(self):
+        assert normalize_column_name("SECTOR  NAME") == "sector_name"
+
+    def test_already_normalized(self):
+        assert normalize_column_name("close") == "close"


### PR DESCRIPTION
## Summary

Adds safe, format-agnostic data parsing utilities: `parse_date_safely` (never-raises, tries 4 known PSX formats then fuzzy dateutil fallback), `coerce_numeric` (strips commas/percent/PKR), and `normalize_column_name` (fallback for unknown COLUMN_MAP headers). Fixes the core `psx-data-reader` bug of hardcoded date formats.

## Related Issue

- Closes #16

## Type of Change

- [x] New feature

## Testing Done

- [x] `pytest tests/unit/test_normalizers.py -v` passes → 27 PASSED
- [ ] `pytest -m reliability -v` passes
- [ ] `pytest -m integration -v` passes locally (required for scraper changes)
- [ ] Manually tested against live PSX endpoint (required for scraper changes)

## Checklist

- [x] Type hints on all new public functions
- [x] Docstrings on all new public functions
- [x] No hardcoded date formats (use `parse_date_safely()`)
- [x] No fixed column position assumptions (map by `<th>` name)
- [x] `ruff check psxdata/ api/` passes
- [x] `mypy psxdata/ api/` passes
- [ ] `CHANGELOG.md` updated (if breaking change or new user-facing feature)
- [ ] New HTML fixture captured if a new PSX endpoint interaction was added