### PR TITLE
[Phase 2] cache/disk_cache.py — diskcache + parquet persistence

### DIFF
--- a/psxdata/cache/disk_cache.py
+++ b/psxdata/cache/disk_cache.py
@@ -1,0 +1,103 @@
+"""Disk-based cache for psxdata DataFrames using diskcache + parquet.
+
+Cache location: ~/.psxdata/cache/ (configurable)
+Serialisation: parquet via pyarrow — preserves dtypes across sessions
+TTL: None (never expires) for historical data; CACHE_TTL_TODAY for today's data
+"""
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import Path
+
+import diskcache
+import pandas as pd
+
+from psxdata.constants import CACHE_DIR
+from psxdata.exceptions import CacheError
+
+logger = logging.getLogger(__name__)
+
+
+class DiskCache:
+    """Persistent DataFrame cache backed by diskcache and parquet serialisation.
+
+    Args:
+        cache_dir: Path to the cache directory. Tilde is expanded.
+            Defaults to CACHE_DIR (~/.psxdata/cache/).
+
+    Key convention (caller's responsibility)::
+
+        # Historical — never expires
+        key = f"{symbol.upper()}_{start.isoformat()}_{end.isoformat()}"
+        # Today's data — use CACHE_TTL_TODAY
+        key = f"{symbol.upper()}_today"
+    """
+
+    def __init__(self, cache_dir: str = CACHE_DIR) -> None:
+        resolved = Path(cache_dir).expanduser()
+        resolved.mkdir(parents=True, exist_ok=True)
+        try:
+            self._cache = diskcache.Cache(str(resolved))
+        except Exception as exc:
+            raise CacheError(f"Failed to open cache at {resolved}") from exc
+
+    def get(self, key: str) -> pd.DataFrame | None:
+        """Retrieve a DataFrame by key.
+
+        Args:
+            key: Cache key string.
+
+        Returns:
+            DataFrame if found and not expired, None on miss.
+
+        Raises:
+            CacheError: On diskcache or parquet deserialisation failure.
+        """
+        try:
+            raw = self._cache.get(key)
+        except Exception as exc:
+            raise CacheError(f"Cache read failed for key {key!r}") from exc
+        if raw is None:
+            return None
+        try:
+            return pd.read_parquet(io.BytesIO(raw))
+        except Exception as exc:
+            raise CacheError(f"Parquet deserialisation failed for key {key!r}") from exc
+
+    def set(self, key: str, df: pd.DataFrame, ttl: int | None = None) -> None:
+        """Store a DataFrame under key with optional TTL.
+
+        Args:
+            key: Cache key string.
+            df: DataFrame to store.
+            ttl: Time-to-live in seconds. None = never expires.
+
+        Raises:
+            CacheError: On serialisation or diskcache write failure.
+        """
+        try:
+            buf = io.BytesIO()
+            df.to_parquet(buf, index=True)
+            raw = buf.getvalue()
+        except Exception as exc:
+            raise CacheError(f"Parquet serialisation failed for key {key!r}") from exc
+        try:
+            self._cache.set(key, raw, expire=ttl)
+        except Exception as exc:
+            raise CacheError(f"Cache write failed for key {key!r}") from exc
+        logger.debug("Cache set: %r (%d bytes, ttl=%s)", key, len(raw), ttl)
+
+    def delete(self, key: str) -> None:
+        """Remove an entry by key. No-op if key doesn't exist."""
+        try:
+            self._cache.delete(key)
+        except Exception as exc:
+            raise CacheError(f"Cache delete failed for key {key!r}") from exc
+
+    def clear(self) -> None:
+        """Remove all entries from the cache."""
+        try:
+            self._cache.clear()
+        except Exception as exc:
+            raise CacheError("Cache clear failed") from exc

--- a/tests/unit/test_disk_cache.py
+++ b/tests/unit/test_disk_cache.py
@@ -1,0 +1,84 @@
+"""Unit tests for psxdata/cache/disk_cache.py."""
+import time
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from psxdata.cache.disk_cache import DiskCache
+
+
+@pytest.fixture
+def cache(tmp_path):
+    """DiskCache instance using a temp directory — isolated per test."""
+    return DiskCache(cache_dir=str(tmp_path / "test_cache"))
+
+
+@pytest.fixture
+def sample_df():
+    return pd.DataFrame({
+        "date": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]),
+        "open": [100.0, 101.0, 102.0],
+        "close": [105.0, 106.0, 107.0],
+        "volume": [1000, 2000, 3000],
+    })
+
+
+class TestDiskCacheMissAndHit:
+    def test_cache_miss_returns_none(self, cache):
+        assert cache.get("ENGRO_2024-01-01_2024-12-31") is None
+
+    def test_write_then_read_returns_equal_df(self, cache, sample_df):
+        key = "ENGRO_2024-01-01_2024-01-03"
+        cache.set(key, sample_df)
+        result = cache.get(key)
+        assert result is not None
+        pd.testing.assert_frame_equal(result, sample_df)
+
+    def test_parquet_round_trip_preserves_dtypes(self, cache, sample_df):
+        key = "DTYPE_TEST"
+        cache.set(key, sample_df)
+        result = cache.get(key)
+        assert result["date"].dtype == sample_df["date"].dtype
+        assert result["open"].dtype == sample_df["open"].dtype
+        assert result["volume"].dtype == sample_df["volume"].dtype
+
+    def test_delete_removes_entry(self, cache, sample_df):
+        key = "TO_DELETE"
+        cache.set(key, sample_df)
+        cache.delete(key)
+        assert cache.get(key) is None
+
+    def test_clear_removes_all_entries(self, cache, sample_df):
+        cache.set("KEY1", sample_df)
+        cache.set("KEY2", sample_df)
+        cache.clear()
+        assert cache.get("KEY1") is None
+        assert cache.get("KEY2") is None
+
+
+class TestDiskCacheTTL:
+    def test_historical_data_never_expires(self, cache, sample_df):
+        cache.set("HIST", sample_df, ttl=None)
+        result = cache.get("HIST")
+        assert result is not None
+
+    def test_today_data_expires_after_ttl(self, cache, sample_df):
+        cache.set("TODAY", sample_df, ttl=1)
+        assert cache.get("TODAY") is not None
+        time.sleep(1.1)
+        assert cache.get("TODAY") is None
+
+
+class TestDiskCacheKeyConvention:
+    def test_standard_key_format(self, cache, sample_df):
+        """Demonstrate the standard caller key convention."""
+        symbol = "engro"
+        start = date(2024, 1, 1)
+        end = date(2024, 12, 31)
+        key = f"{symbol.upper()}_{start.isoformat()}_{end.isoformat()}"
+        assert key == "ENGRO_2024-01-01_2024-12-31"
+        cache.set(key, sample_df)
+        assert cache.get(key) is not None
+        # Different case misses — key is caller's responsibility
+        assert cache.get("engro_2024-01-01_2024-12-31") is None


### PR DESCRIPTION
## Summary

Adds `DiskCache` — a persistent DataFrame cache backed by `diskcache` and parquet serialisation. Historical data never expires (`ttl=None`), today's prices use `CACHE_TTL_TODAY` (15 min). All `diskcache` errors are wrapped as `CacheError`. Key convention is caller-owned: `f"{symbol.upper()}_{start.isoformat()}_{end.isoformat()}"`.

## Related Issue

- Closes #18

## Type of Change

- [x] New feature

## Testing Done

- [x] `pytest tests/unit/test_disk_cache.py -v` passes → 8 PASSED
- [ ] `pytest -m reliability -v` passes
- [ ] `pytest -m integration -v` passes locally (required for scraper changes)
- [ ] Manually tested against live PSX endpoint (required for scraper changes)

## Checklist

- [x] Type hints on all new public functions
- [x] Docstrings on all new public functions
- [x] No hardcoded date formats (use `parse_date_safely()`)
- [x] No fixed column position assumptions (map by `<th>` name)
- [x] `ruff check psxdata/ api/` passes
- [x] `mypy psxdata/ api/` passes
- [ ] `CHANGELOG.md` updated (if breaking change or new user-facing feature)
- [ ] New HTML fixture captured if a new PSX endpoint interaction was added