### PR TITLE
fix: add missing pyarrow dep and mypy type stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "beautifulsoup4>=4.11",
     "lxml>=4.9",
     "pandas>=2.0",
+    "pyarrow>=14.0",
     "python-dateutil>=2.8",
     "tqdm>=4.64",
     "diskcache>=5.4",
@@ -46,6 +47,8 @@ dev = [
     "httpx>=0.24",
     "ruff>=0.4",
     "mypy>=1.0",
+    "types-requests>=2.28",
+    "types-python-dateutil>=2.8",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

Fixes two CI failures on PR #29:

1. **mypy errors** — `types-requests` and `types-python-dateutil` stubs missing from `dev` dependencies. mypy reported `import-untyped` errors for `requests` and `dateutil`.
2. **cache tests failing** — `pyarrow` was specified in the spec but never added to `pyproject.toml`. CI environment had no pyarrow, causing all `DiskCache` parquet tests to fail.

## Related Issue

- Fixes CI on #29

## Type of Change

- [x] Bug fix

## Testing Done

- [x] `mypy psxdata/ --ignore-missing-imports` → Success: no issues found in 13 source files
- [x] `pytest tests/unit/ tests/reliability/ -v -m "not integration"` → 93 PASSED
- [x] `pytest -m reliability -v` passes
- [ ] `pytest -m integration -v` passes locally (required for scraper changes)
- [ ] Manually tested against live PSX endpoint (required for scraper changes)

## Checklist

- [x] Type hints on all new public functions
- [x] Docstrings on all new public functions
- [x] No hardcoded date formats (use `parse_date_safely()`)
- [x] No fixed column position assumptions (map by `<th>` name)
- [x] `ruff check psxdata/ api/` passes
- [x] `mypy psxdata/ api/` passes
- [ ] `CHANGELOG.md` updated (if breaking change or new user-facing feature)
- [ ] New HTML fixture captured if a new PSX endpoint interaction was added