### PR TITLE
test: 18 unit tests for PSXClient

### DIFF
--- a/psxdata/__init__.py
+++ b/psxdata/__init__.py
@@ -1,16 +1,28 @@
-"""psxdata — Python library for Pakistan Stock Exchange data.
-
-Public API (implemented in Phase 3):
-    stocks(symbol, start, end)     — historical OHLCV data
-    tickers(index=None)            — all listed tickers
-    indices(name, start, end)      — index historical data
-    sectors(name=None)             — sector summaries
-    fundamentals(symbol)           — P/E, EPS, Book Value
-"""
+"""psxdata — Python library for Pakistan Stock Exchange data."""
 from psxdata.scrapers.base import BaseScraper
+from psxdata.client import (
+    PSXClient,
+    stocks,
+    tickers,
+    quote,
+    indices,
+    sectors,
+    fundamentals,
+    debt_market,
+    eligible_scrips,
+)
 
 __version__ = "0.1.0"
-__all__ = ["BaseScraper"]
 
-# Public API — implemented in Phase 3 API (psxdata/client.py)
-# from psxdata.client import stocks, tickers, indices, sectors, fundamentals, market
+__all__ = [
+    "BaseScraper",
+    "PSXClient",
+    "stocks",
+    "tickers",
+    "quote",
+    "indices",
+    "sectors",
+    "fundamentals",
+    "debt_market",
+    "eligible_scrips",
+]

--- a/psxdata/client.py
+++ b/psxdata/client.py
@@ -1,0 +1,439 @@
+"""PSXClient — high-level public API for psxdata.
+
+Owns the DiskCache and all scraper instances. Scrapers are stateless
+except for their requests.Session and never touch the cache directly.
+
+Module-level convenience functions wrap a lazy default PSXClient so callers
+can use ``import psxdata; psxdata.stocks("ENGRO")`` without instantiation.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+import pandas as pd
+
+from psxdata.cache.disk_cache import DiskCache
+from psxdata.constants import CACHE_DIR, CACHE_TTL_TODAY
+from psxdata.scrapers.debt_market import DebtMarketScraper
+from psxdata.scrapers.eligible_scrips import EligibleScripsScraper
+from psxdata.scrapers.fundamentals import FundamentalsScraper
+from psxdata.scrapers.historical import HistoricalScraper
+from psxdata.scrapers.indices import IndicesScraper
+from psxdata.scrapers.screener import ScreenerScraper
+from psxdata.scrapers.sectors import SectorsScraper
+from psxdata.scrapers.symbols import SymbolsScraper
+
+logger = logging.getLogger(__name__)
+
+
+class PSXClient:
+    """Public Python API for Pakistan Stock Exchange data.
+
+    All scrapers are instantiated once in ``__init__`` and reused across calls.
+    Caching is managed here — scrapers never touch the cache.
+
+    Args:
+        cache_dir: Path to the cache directory. Tilde is expanded.
+            Defaults to ``~/.psxdata/cache/``.
+
+    Example::
+
+        client = PSXClient()
+        df = client.stocks("ENGRO", start="2024-01-01")
+    """
+
+    def __init__(self, cache_dir: str = CACHE_DIR) -> None:
+        self._cache = DiskCache(cache_dir)
+        self._historical = HistoricalScraper()
+        self._screener = ScreenerScraper()
+        self._symbols = SymbolsScraper()
+        self._indices = IndicesScraper()
+        self._sectors = SectorsScraper()
+        self._fundamentals = FundamentalsScraper()
+        self._debt_market = DebtMarketScraper()
+        self._eligible_scrips = EligibleScripsScraper()
+
+    # ------------------------------------------------------------------
+    # Public methods
+    # ------------------------------------------------------------------
+
+    def stocks(
+        self,
+        symbol: str,
+        start: date | str | None = None,
+        end: date | str | None = None,
+        cache: bool = True,
+    ) -> pd.DataFrame:
+        """Fetch historical OHLCV data for a symbol.
+
+        PSX returns all history in a single request. The response is split
+        at today's boundary and stored under two cache keys:
+
+        - ``{SYMBOL}_historical`` — rows before today, TTL=None (never expires)
+        - ``{SYMBOL}_today`` — rows from today, TTL=15 min (intraday prices change)
+
+        Args:
+            symbol: PSX ticker, e.g. ``"ENGRO"``.
+            start: Start date (inclusive). ``None`` means earliest available.
+            end: End date (inclusive). ``None`` means today.
+            cache: If ``False``, bypass cache and always fetch from PSX.
+
+        Returns:
+            DataFrame with columns: date, open, high, low, close, volume, is_anomaly.
+            Empty DataFrame if no data is available for the given range.
+
+        Raises:
+            ValueError: If ``start`` is after ``end``.
+            PSXConnectionError: Network failure after retries.
+            PSXServerError: 5xx after retries.
+        """
+        sym = symbol.upper()
+        today = pd.Timestamp.today().normalize()
+
+        start_ts = pd.Timestamp(start) if start is not None else None
+        end_ts = pd.Timestamp(end) if end is not None else today
+
+        if start_ts is not None and start_ts > end_ts:
+            raise ValueError(f"start ({start}) must not be after end ({end})")
+
+        hist_key = f"{sym}_historical"
+        today_key = f"{sym}_today"
+        need_today = end_ts >= today
+
+        if cache:
+            hist_cached = self._cache.get(hist_key)
+            today_cached = self._cache.get(today_key) if need_today else None
+
+            if hist_cached is not None and (not need_today or today_cached is not None):
+                parts = [hist_cached]
+                if need_today and today_cached is not None:
+                    parts.append(today_cached)
+                df = pd.concat(parts, ignore_index=True)
+                return self._filter_date_range(df, start_ts, end_ts)
+
+        logger.debug("Fetching historical data for %s from PSX", sym)
+        raw = self._historical.fetch(sym, start=None, end=None)
+
+        if raw.empty:
+            return raw
+
+        if cache:
+            hist_df = raw[raw["date"] < today].copy()
+            today_df = raw[raw["date"] >= today].copy()
+            self._cache.set(hist_key, hist_df, ttl=None)
+            if not today_df.empty:
+                self._cache.set(today_key, today_df, ttl=CACHE_TTL_TODAY)
+
+        return self._filter_date_range(raw, start_ts, end_ts)
+
+    def quote(self, symbol: str, cache: bool = True) -> pd.DataFrame:
+        """Fetch the latest screener snapshot for a symbol.
+
+        The full screener (~729 symbols) is fetched once and cached for 15 minutes.
+        Successive calls for different symbols reuse the same cached screener.
+
+        Args:
+            symbol: PSX ticker, e.g. ``"ENGRO"``.
+            cache: If ``False``, bypass cache and always fetch the screener.
+
+        Returns:
+            Single-row DataFrame with screener columns (symbol, sector, price, …).
+            Empty DataFrame if the symbol is not present in the screener.
+
+        Raises:
+            PSXConnectionError: Network failure after retries.
+            PSXServerError: 5xx after retries.
+        """
+        cache_key = "screener_all"
+        screener_df: pd.DataFrame | None = None
+
+        if cache:
+            screener_df = self._cache.get(cache_key)
+
+        if screener_df is None:
+            logger.debug("Fetching screener from PSX")
+            screener_df = self._screener.fetch()
+            if cache and not screener_df.empty:
+                self._cache.set(cache_key, screener_df, ttl=CACHE_TTL_TODAY)
+
+        if screener_df.empty or "symbol" not in screener_df.columns:
+            return pd.DataFrame()
+
+        match = screener_df[screener_df["symbol"] == symbol.upper()]
+        return match.reset_index(drop=True)
+
+    def tickers(self, index: str | None = None, cache: bool = True) -> list[str]:
+        """Return PSX ticker symbols, optionally filtered to an index.
+
+        Args:
+            index: Index name, e.g. ``"KSE100"``. ``None`` returns all listed
+                symbols. See ``constants.INDEX_NAMES`` for valid names.
+            cache: If ``False``, bypass cache.
+
+        Returns:
+            List of ticker strings, e.g. ``["ENGRO", "LUCK", ...]``.
+            Empty list if no symbols are found.
+
+        Raises:
+            PSXConnectionError: Network failure after retries.
+            PSXServerError: 5xx after retries.
+            PSXParseError: PSX returned 4xx for the given index name.
+        """
+        if index is None:
+            cache_key = "symbols_all"
+            df: pd.DataFrame | None = None
+
+            if cache:
+                df = self._cache.get(cache_key)
+
+            if df is None:
+                logger.debug("Fetching all symbols from PSX")
+                df = self._symbols.fetch()
+                if cache and not df.empty:
+                    self._cache.set(cache_key, df, ttl=CACHE_TTL_TODAY)
+        else:
+            df = self._get_index_df(index.upper(), cache=cache)
+
+        if df is None or df.empty or "symbol" not in df.columns:
+            return []
+        return df["symbol"].tolist()
+
+    def indices(self, name: str, cache: bool = True) -> pd.DataFrame:
+        """Fetch constituent data for a PSX index.
+
+        ``tickers(index="KSE100")`` and ``indices("KSE100")`` share the same
+        cache key (``indices_KSE100``), so the two methods never double-fetch.
+
+        Args:
+            name: Index name, e.g. ``"KSE100"``. See ``constants.INDEX_NAMES``.
+            cache: If ``False``, bypass cache.
+
+        Returns:
+            DataFrame with columns: symbol, current_index, idx_weight,
+            idx_point, market_cap_m, and either freefloat_m or shares_m.
+            Empty DataFrame if PSX returns no data.
+
+        Raises:
+            PSXConnectionError: Network failure after retries.
+            PSXServerError: 5xx after retries.
+            PSXParseError: PSX returned 4xx for the given index name.
+        """
+        df = self._get_index_df(name.upper(), cache=cache)
+        return df if df is not None else pd.DataFrame()
+
+    def sectors(self, cache: bool = True) -> pd.DataFrame:
+        """Fetch the PSX sector summary.
+
+        Args:
+            cache: If ``False``, bypass cache.
+
+        Returns:
+            DataFrame with columns: sector_code, sector_name, advance, decline,
+            unchanged, turnover, market_cap_b.
+
+        Raises:
+            PSXConnectionError: Network failure after retries.
+            PSXServerError: 5xx after retries.
+        """
+        cache_key = "sectors_all"
+        df: pd.DataFrame | None = None
+
+        if cache:
+            df = self._cache.get(cache_key)
+
+        if df is None:
+            logger.debug("Fetching sectors from PSX")
+            df = self._sectors.fetch()
+            if cache and not df.empty:
+                self._cache.set(cache_key, df, ttl=CACHE_TTL_TODAY)
+
+        return df if df is not None else pd.DataFrame()
+
+    def fundamentals(self, symbol: str | None = None, cache: bool = True) -> pd.DataFrame:
+        """Fetch the PSX financial reports filing list.
+
+        PSX returns all filings in a single request. When ``symbol`` is given,
+        the result is filtered in memory.
+
+        Args:
+            symbol: If provided, return only filings for this ticker.
+            cache: If ``False``, bypass cache.
+
+        Returns:
+            DataFrame with columns: symbol, year, type, period_ended,
+            posting_date, posting_time, document.
+            Empty DataFrame if outside reporting season or no data returned.
+
+        Raises:
+            PSXConnectionError: Network failure after retries.
+            PSXServerError: 5xx after retries.
+        """
+        cache_key = "fundamentals_all"
+        df: pd.DataFrame | None = None
+
+        if cache:
+            df = self._cache.get(cache_key)
+
+        if df is None:
+            logger.debug("Fetching financial reports from PSX")
+            df = self._fundamentals.fetch()
+            if cache and not df.empty:
+                self._cache.set(cache_key, df, ttl=CACHE_TTL_TODAY)
+
+        if df is None or df.empty:
+            return pd.DataFrame()
+
+        if symbol is not None and "symbol" in df.columns:
+            df = df[df["symbol"] == symbol.upper()].reset_index(drop=True)
+
+        return df
+
+    def debt_market(self, cache: bool = True) -> dict[str, pd.DataFrame]:
+        """Fetch all PSX debt market instrument tables.
+
+        Returns 4 tables. Keys are ``table_0`` through ``table_3`` (fallback
+        index keys — the /debt-market page has no ``<h2>`` headings before its
+        tables, so heading-based keys are not available). These key names are
+        load-bearing: do not change them.
+
+        Disk caching for ``dict[str, DataFrame]`` values is deferred — see
+        issue #60. The ``cache`` parameter is accepted for API consistency
+        (project-wide policy: cache always-on, opt-out via ``cache=False``)
+        but is currently a no-op.
+
+        Args:
+            cache: Accepted for API consistency; currently a no-op. See #60.
+
+        Returns:
+            ``dict`` mapping ``table_0``..``table_3`` → DataFrame.
+            Empty dict if no tables are found.
+
+        Raises:
+            PSXConnectionError: Network failure after retries.
+            PSXServerError: 5xx after retries.
+        """
+        logger.debug("Fetching debt market data from PSX")
+        return self._debt_market.fetch()
+
+    def eligible_scrips(self, cache: bool = True) -> dict[str, pd.DataFrame]:
+        """Fetch all PSX margin-trading eligible scrip tables.
+
+        Returns 9 tables. Keys are ``table_0`` through ``table_8`` (fallback
+        index keys — the /eligible-scrips ``<h2>`` headings are not direct
+        siblings of ``<table>`` elements, so heading-based keys are not
+        available). These key names are load-bearing: do not change them.
+
+        Disk caching for ``dict[str, DataFrame]`` values is deferred — see
+        issue #60. The ``cache`` parameter is accepted for API consistency
+        (project-wide policy: cache always-on, opt-out via ``cache=False``)
+        but is currently a no-op.
+
+        Args:
+            cache: Accepted for API consistency; currently a no-op. See #60.
+
+        Returns:
+            ``dict`` mapping ``table_0``..``table_8`` → DataFrame.
+            Empty dict if no tables are found.
+
+        Raises:
+            PSXConnectionError: Network failure after retries.
+            PSXServerError: 5xx after retries.
+        """
+        logger.debug("Fetching eligible scrips from PSX")
+        return self._eligible_scrips.fetch()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_index_df(self, name: str, cache: bool = True) -> pd.DataFrame | None:
+        """Fetch or retrieve from cache the constituent DataFrame for *name*."""
+        cache_key = f"indices_{name}"
+        df: pd.DataFrame | None = None
+
+        if cache:
+            df = self._cache.get(cache_key)
+
+        if df is None:
+            logger.debug("Fetching index %s from PSX", name)
+            df = self._indices.fetch(name)
+            if cache and not df.empty:
+                self._cache.set(cache_key, df, ttl=CACHE_TTL_TODAY)
+
+        return df
+
+    def _filter_date_range(
+        self,
+        df: pd.DataFrame,
+        start: pd.Timestamp | None,
+        end: pd.Timestamp | None,
+    ) -> pd.DataFrame:
+        """Apply an inclusive ``[start, end]`` filter on the ``date`` column."""
+        if df.empty:
+            return df
+        mask = pd.Series(True, index=df.index)
+        if start is not None:
+            mask &= df["date"] >= start
+        if end is not None:
+            mask &= df["date"] <= end
+        return df[mask].reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience API
+# ---------------------------------------------------------------------------
+
+_default_client: PSXClient | None = None
+
+
+def _client() -> PSXClient:
+    global _default_client
+    if _default_client is None:
+        _default_client = PSXClient()
+    return _default_client
+
+
+def stocks(
+    symbol: str,
+    start: date | str | None = None,
+    end: date | str | None = None,
+    cache: bool = True,
+) -> pd.DataFrame:
+    """Fetch historical OHLCV data. See :class:`PSXClient.stocks` for full docs."""
+    return _client().stocks(symbol, start=start, end=end, cache=cache)
+
+
+def quote(symbol: str, cache: bool = True) -> pd.DataFrame:
+    """Fetch screener snapshot for a symbol. See :class:`PSXClient.quote` for full docs."""
+    return _client().quote(symbol, cache=cache)
+
+
+def tickers(index: str | None = None, cache: bool = True) -> list[str]:
+    """Return ticker symbols. See :class:`PSXClient.tickers` for full docs."""
+    return _client().tickers(index=index, cache=cache)
+
+
+def indices(name: str, cache: bool = True) -> pd.DataFrame:
+    """Fetch index constituents. See :class:`PSXClient.indices` for full docs."""
+    return _client().indices(name, cache=cache)
+
+
+def sectors(cache: bool = True) -> pd.DataFrame:
+    """Fetch sector summary. See :class:`PSXClient.sectors` for full docs."""
+    return _client().sectors(cache=cache)
+
+
+def fundamentals(symbol: str | None = None, cache: bool = True) -> pd.DataFrame:
+    """Fetch financial reports list. See :class:`PSXClient.fundamentals` for full docs."""
+    return _client().fundamentals(symbol=symbol, cache=cache)
+
+
+def debt_market(cache: bool = True) -> dict[str, pd.DataFrame]:
+    """Fetch debt market tables. See :class:`PSXClient.debt_market` for full docs."""
+    return _client().debt_market(cache=cache)
+
+
+def eligible_scrips(cache: bool = True) -> dict[str, pd.DataFrame]:
+    """Fetch eligible scrip tables. See :class:`PSXClient.eligible_scrips` for full docs."""
+    return _client().eligible_scrips(cache=cache)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,0 +1,308 @@
+"""Unit tests for psxdata/client.py — all mocked, no network required."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from psxdata.client import PSXClient
+from psxdata.constants import CACHE_TTL_TODAY
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client(tmp_path):
+    """PSXClient with a real isolated DiskCache and all scrapers replaced by MagicMocks."""
+    c = PSXClient(cache_dir=str(tmp_path / "cache"))
+    c._historical = MagicMock()
+    c._screener = MagicMock()
+    c._symbols = MagicMock()
+    c._indices = MagicMock()
+    c._sectors = MagicMock()
+    c._fundamentals = MagicMock()
+    c._debt_market = MagicMock()
+    c._eligible_scrips = MagicMock()
+    return c
+
+
+@pytest.fixture
+def today():
+    return pd.Timestamp.today().normalize()
+
+
+@pytest.fixture
+def ohlcv_df(today):
+    """Sample OHLCV DataFrame spanning yesterday and today."""
+    yesterday = today - pd.Timedelta(days=1)
+    return pd.DataFrame({
+        "date": [yesterday, today],
+        "open": [100.0, 101.0],
+        "high": [105.0, 106.0],
+        "low": [98.0, 99.0],
+        "close": [103.0, 104.0],
+        "volume": pd.array([10000, 11000], dtype="Int64"),
+        "is_anomaly": [False, False],
+    })
+
+
+@pytest.fixture
+def hist_only_df(today):
+    """Sample OHLCV DataFrame with only historical rows (all dates before today)."""
+    day_before = today - pd.Timedelta(days=2)
+    yesterday = today - pd.Timedelta(days=1)
+    return pd.DataFrame({
+        "date": [day_before, yesterday],
+        "open": [100.0, 101.0],
+        "high": [105.0, 106.0],
+        "low": [98.0, 99.0],
+        "close": [103.0, 104.0],
+        "volume": pd.array([10000, 11000], dtype="Int64"),
+        "is_anomaly": [False, False],
+    })
+
+
+@pytest.fixture
+def screener_df():
+    return pd.DataFrame({
+        "symbol": ["ENGRO", "LUCK", "HBL"],
+        "price": [250.0, 150.0, 100.0],
+        "market_cap": [1e9, 5e8, 8e8],
+    })
+
+
+@pytest.fixture
+def symbols_df():
+    return pd.DataFrame({
+        "symbol": ["ENGRO", "LUCK", "HBL"],
+        "name": ["Engro Corp", "Lucky Cement", "HBL"],
+        "sector_name": ["Fertilizer", "Cement", "Banks"],
+    })
+
+
+@pytest.fixture
+def indices_df():
+    return pd.DataFrame({
+        "symbol": ["ENGRO", "LUCK"],
+        "current_index": [45000.0, 45100.0],
+        "idx_weight": [2.5, 1.8],
+    })
+
+
+@pytest.fixture
+def sectors_df():
+    return pd.DataFrame({
+        "sector_code": [1, 2],
+        "sector_name": ["Fertilizer", "Cement"],
+        "advance": [5, 3],
+        "decline": [2, 4],
+        "unchanged": [1, 1],
+        "turnover": [1e8, 5e7],
+        "market_cap_b": [50.0, 30.0],
+    })
+
+
+@pytest.fixture
+def fundamentals_df():
+    return pd.DataFrame({
+        "symbol": ["ENGRO", "ENGRO", "LUCK"],
+        "year": [2024, 2023, 2024],
+        "type": ["Annual", "Annual", "Annual"],
+        "period_ended": pd.to_datetime(["2024-12-31", "2023-12-31", "2024-12-31"]),
+        "posting_date": pd.to_datetime(["2025-02-15", "2024-02-10", "2025-02-20"]),
+    })
+
+
+# ---------------------------------------------------------------------------
+# stocks()
+# ---------------------------------------------------------------------------
+
+class TestStocks:
+    def test_stocks_cache_miss_fetches_scraper(self, client, ohlcv_df):
+        """On cache miss the scraper is called and the result is returned."""
+        client._historical.fetch.return_value = ohlcv_df
+        result = client.stocks("ENGRO", cache=True)
+        client._historical.fetch.assert_called_once_with("ENGRO", start=None, end=None)
+        assert not result.empty
+
+    def test_stocks_cache_hit_skips_scraper(self, client, hist_only_df, today):
+        """When historical data is cached and today is not needed, scraper is not called."""
+        yesterday = today - pd.Timedelta(days=1)
+        client._cache.set("ENGRO_historical", hist_only_df, ttl=None)
+        result = client.stocks("ENGRO", end=yesterday.date(), cache=True)
+        client._historical.fetch.assert_not_called()
+        assert len(result) == len(hist_only_df)
+
+    def test_stocks_today_split_cached_separately(self, client, ohlcv_df):
+        """After a cache miss, historical and today rows are stored under separate keys."""
+        client._historical.fetch.return_value = ohlcv_df
+        client.stocks("ENGRO", cache=True)
+        hist_cached = client._cache.get("ENGRO_historical")
+        today_cached = client._cache.get("ENGRO_today")
+        assert hist_cached is not None, "historical rows should be cached"
+        assert today_cached is not None, "today rows should be cached"
+        # Historical rows exclude today; today rows include today
+        today_ts = pd.Timestamp.today().normalize()
+        assert (hist_cached["date"] < today_ts).all()
+        assert (today_cached["date"] >= today_ts).all()
+
+    def test_stocks_cache_false_bypasses_cache(self, client, ohlcv_df):
+        """cache=False always calls the scraper regardless of what is in cache."""
+        client._historical.fetch.return_value = ohlcv_df
+        client.stocks("ENGRO", cache=True)   # populates cache
+        client.stocks("ENGRO", cache=False)  # must bypass and call again
+        assert client._historical.fetch.call_count == 2
+
+    def test_stocks_invalid_range_raises(self, client):
+        """start > end raises ValueError before any scraper call."""
+        with pytest.raises(ValueError, match="must not be after"):
+            client.stocks("ENGRO", start="2024-12-31", end="2024-01-01")
+        client._historical.fetch.assert_not_called()
+
+    def test_stocks_empty_response(self, client):
+        """Scraper returning empty DataFrame is forwarded unchanged."""
+        empty = pd.DataFrame(
+            columns=["date", "open", "high", "low", "close", "volume", "is_anomaly"]
+        )
+        client._historical.fetch.return_value = empty
+        result = client.stocks("ENGRO", cache=False)
+        assert result.empty
+        assert list(result.columns) == [
+            "date", "open", "high", "low", "close", "volume", "is_anomaly"
+        ]
+
+
+# ---------------------------------------------------------------------------
+# quote()
+# ---------------------------------------------------------------------------
+
+class TestQuote:
+    def test_quote_returns_matching_row(self, client, screener_df):
+        """quote() returns the single row matching the requested symbol."""
+        client._screener.fetch.return_value = screener_df
+        result = client.quote("ENGRO", cache=False)
+        assert len(result) == 1
+        assert result["symbol"].iloc[0] == "ENGRO"
+
+    def test_quote_unknown_symbol_returns_empty(self, client, screener_df):
+        """Symbol absent from the screener returns an empty DataFrame."""
+        client._screener.fetch.return_value = screener_df
+        result = client.quote("XXXX", cache=False)
+        assert result.empty
+
+    def test_quote_caches_screener(self, client, screener_df):
+        """Screener is fetched once; subsequent calls for different symbols reuse it."""
+        client._screener.fetch.return_value = screener_df
+        client.quote("ENGRO", cache=True)
+        client.quote("LUCK", cache=True)
+        client._screener.fetch.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# tickers()
+# ---------------------------------------------------------------------------
+
+class TestTickers:
+    def test_tickers_no_index(self, client, symbols_df):
+        """tickers() with no index returns all symbol strings from SymbolsScraper."""
+        client._symbols.fetch.return_value = symbols_df
+        result = client.tickers(cache=False)
+        client._symbols.fetch.assert_called_once()
+        assert result == ["ENGRO", "LUCK", "HBL"]
+        assert isinstance(result, list)
+        assert all(isinstance(s, str) for s in result)
+
+    def test_tickers_with_index(self, client, indices_df):
+        """tickers(index=...) uses IndicesScraper and extracts the symbol column."""
+        client._indices.fetch.return_value = indices_df
+        result = client.tickers(index="KSE100", cache=False)
+        client._indices.fetch.assert_called_once_with("KSE100")
+        assert result == ["ENGRO", "LUCK"]
+
+    def test_tickers_empty_result(self, client):
+        """Scraper returning empty DataFrame yields an empty list."""
+        client._symbols.fetch.return_value = pd.DataFrame()
+        result = client.tickers(cache=False)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# indices()
+# ---------------------------------------------------------------------------
+
+class TestIndices:
+    def test_indices_returns_dataframe(self, client, indices_df):
+        """indices() returns the full constituent DataFrame from IndicesScraper."""
+        client._indices.fetch.return_value = indices_df
+        result = client.indices("KSE100", cache=False)
+        client._indices.fetch.assert_called_once_with("KSE100")
+        pd.testing.assert_frame_equal(result, indices_df)
+
+
+# ---------------------------------------------------------------------------
+# sectors()
+# ---------------------------------------------------------------------------
+
+class TestSectors:
+    def test_sectors_returns_dataframe(self, client, sectors_df):
+        """sectors() returns the full sector summary DataFrame."""
+        client._sectors.fetch.return_value = sectors_df
+        result = client.sectors(cache=False)
+        client._sectors.fetch.assert_called_once()
+        pd.testing.assert_frame_equal(result, sectors_df)
+
+
+# ---------------------------------------------------------------------------
+# fundamentals()
+# ---------------------------------------------------------------------------
+
+class TestFundamentals:
+    def test_fundamentals_no_filter(self, client, fundamentals_df):
+        """fundamentals() with no symbol returns all rows."""
+        client._fundamentals.fetch.return_value = fundamentals_df
+        result = client.fundamentals(cache=False)
+        assert len(result) == len(fundamentals_df)
+
+    def test_fundamentals_symbol_filter(self, client, fundamentals_df):
+        """fundamentals(symbol=...) filters rows in memory by symbol."""
+        client._fundamentals.fetch.return_value = fundamentals_df
+        result = client.fundamentals(symbol="ENGRO", cache=False)
+        assert len(result) == 2
+        assert (result["symbol"] == "ENGRO").all()
+
+
+# ---------------------------------------------------------------------------
+# debt_market()
+# ---------------------------------------------------------------------------
+
+class TestDebtMarket:
+    def test_debt_market_returns_dict(self, client):
+        """debt_market() passes through the scraper result; cache flag is a no-op."""
+        mock_tables = {
+            "table_0": pd.DataFrame({"security_name": ["Bond A"]}),
+            "table_1": pd.DataFrame({"security_name": ["Bond B"]}),
+        }
+        client._debt_market.fetch.return_value = mock_tables
+        result = client.debt_market(cache=True)
+        client._debt_market.fetch.assert_called_once()
+        assert set(result.keys()) == {"table_0", "table_1"}
+
+
+# ---------------------------------------------------------------------------
+# eligible_scrips()
+# ---------------------------------------------------------------------------
+
+class TestEligibleScrips:
+    def test_eligible_scrips_returns_dict(self, client):
+        """eligible_scrips() passes through the scraper result; cache flag is a no-op."""
+        mock_tables = {
+            f"table_{i}": pd.DataFrame({"symbol": [f"SYM{i}"]})
+            for i in range(9)
+        }
+        client._eligible_scrips.fetch.return_value = mock_tables
+        result = client.eligible_scrips(cache=True)
+        client._eligible_scrips.fetch.assert_called_once()
+        assert set(result.keys()) == {f"table_{i}" for i in range(9)}


### PR DESCRIPTION
## Summary

Adds `tests/unit/test_client.py` — 18 mocked unit tests for `PSXClient`. No network required.

## Coverage

| Class | Tests |
|---|---|
| `TestStocks` | cache miss/hit, today-split caching, `cache=False` bypass, `ValueError` on invalid range, empty scraper response |
| `TestQuote` | symbol match, unknown symbol returns empty, screener reused across calls |
| `TestTickers` | no-index path, index path, empty scraper response |
| `TestIndices` | DataFrame pass-through |
| `TestSectors` | DataFrame pass-through |
| `TestFundamentals` | unfiltered result, symbol-filtered result |
| `TestDebtMarket` | dict pass-through, `cache=True` confirmed as no-op |
| `TestEligibleScrips` | dict pass-through with 9-table fixture |

## Test plan

- [ ] `python -m pytest tests/unit/test_client.py -v` — 18/18 pass
- [ ] `python -m pytest tests/ -q` — no regressions in full suite

Depends on #61
Closes #59
Related to #58
Related to #60
Part of #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)