### PR TITLE
feat: disk caching for debt_market and eligible_scrips

### DIFF
--- a/psxdata/cache/disk_cache.py
+++ b/psxdata/cache/disk_cache.py
@@ -88,6 +88,53 @@ class DiskCache:
             raise CacheError(f"Cache write failed for key {key!r}") from exc
         logger.debug("Cache set: %r (%d bytes, ttl=%s)", key, len(raw), ttl)
 
+    def get_dict(self, key: str) -> dict[str, pd.DataFrame] | None:
+        """Retrieve a dict of DataFrames stored under *key*.
+
+        Returns None on any miss (including partial — manifest present but a
+        table entry expired). Treat None as a full cache miss and re-fetch.
+
+        Args:
+            key: Base cache key used in the matching ``set_dict`` call.
+
+        Returns:
+            ``dict[str, DataFrame]`` if all entries are present, else ``None``.
+
+        Raises:
+            CacheError: On read or deserialisation failure.
+        """
+        manifest = self.get(f"{key}__manifest")
+        if manifest is None:
+            return None
+        result: dict[str, pd.DataFrame] = {}
+        for k in manifest["table_key"]:
+            df = self.get(f"{key}__{k}")
+            if df is None:
+                return None  # partial hit — treat as full miss
+            result[k] = df
+        return result
+
+    def set_dict(self, key: str, tables: dict[str, pd.DataFrame], ttl: int | None = None) -> None:
+        """Store a dict of DataFrames under *key*.
+
+        Writes a manifest entry plus one parquet entry per table, all sharing
+        the same TTL so partial-hit logic in ``get_dict`` stays simple.
+
+        Args:
+            key: Base cache key. Individual entries use ``{key}__manifest``
+                and ``{key}__{table_key}`` — the ``__`` separator avoids
+                collision with ``{SYM}_today`` / ``{SYM}_historical`` keys.
+            tables: Mapping of table name → DataFrame.
+            ttl: Time-to-live in seconds. None = never expires.
+
+        Raises:
+            CacheError: On serialisation or write failure.
+        """
+        manifest = pd.DataFrame({"table_key": list(tables.keys())})
+        self.set(f"{key}__manifest", manifest, ttl=ttl)
+        for k, df in tables.items():
+            self.set(f"{key}__{k}", df, ttl=ttl)
+
     def delete(self, key: str) -> None:
         """Remove an entry by key. No-op if key doesn't exist."""
         try:

--- a/psxdata/client.py
+++ b/psxdata/client.py
@@ -320,13 +320,8 @@ class PSXClient:
         tables, so heading-based keys are not available). These key names are
         load-bearing: do not change them.
 
-        Disk caching for ``dict[str, DataFrame]`` values is deferred — see
-        issue #60. The ``cache`` parameter is accepted for API consistency
-        (project-wide policy: cache always-on, opt-out via ``cache=False``)
-        but is currently a no-op.
-
         Args:
-            cache: Accepted for API consistency; currently a no-op. See #60.
+            cache: If ``False``, bypass cache and always fetch from PSX.
 
         Returns:
             ``dict`` mapping ``table_0``..``table_3`` → DataFrame.
@@ -336,8 +331,18 @@ class PSXClient:
             PSXConnectionError: Network failure after retries.
             PSXServerError: 5xx after retries.
         """
+        cache_key = "debt_market_all"
+
+        if cache:
+            cached = self._cache.get_dict(cache_key)
+            if cached is not None:
+                return cached
+
         logger.debug("Fetching debt market data from PSX")
-        return self._debt_market.fetch()
+        data = self._debt_market.fetch()
+        if cache and data:
+            self._cache.set_dict(cache_key, data, ttl=CACHE_TTL_TODAY)
+        return data
 
     def eligible_scrips(self, cache: bool = True) -> dict[str, pd.DataFrame]:
         """Fetch all PSX margin-trading eligible scrip tables.
@@ -347,13 +352,8 @@ class PSXClient:
         siblings of ``<table>`` elements, so heading-based keys are not
         available). These key names are load-bearing: do not change them.
 
-        Disk caching for ``dict[str, DataFrame]`` values is deferred — see
-        issue #60. The ``cache`` parameter is accepted for API consistency
-        (project-wide policy: cache always-on, opt-out via ``cache=False``)
-        but is currently a no-op.
-
         Args:
-            cache: Accepted for API consistency; currently a no-op. See #60.
+            cache: If ``False``, bypass cache and always fetch from PSX.
 
         Returns:
             ``dict`` mapping ``table_0``..``table_8`` → DataFrame.
@@ -363,8 +363,18 @@ class PSXClient:
             PSXConnectionError: Network failure after retries.
             PSXServerError: 5xx after retries.
         """
+        cache_key = "eligible_scrips_all"
+
+        if cache:
+            cached = self._cache.get_dict(cache_key)
+            if cached is not None:
+                return cached
+
         logger.debug("Fetching eligible scrips from PSX")
-        return self._eligible_scrips.fetch()
+        data = self._eligible_scrips.fetch()
+        if cache and data:
+            self._cache.set_dict(cache_key, data, ttl=CACHE_TTL_TODAY)
+        return data
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -316,16 +316,33 @@ class TestFundamentals:
 # ---------------------------------------------------------------------------
 
 class TestDebtMarket:
-    def test_debt_market_returns_dict(self, client):
-        """debt_market() passes through the scraper result; cache flag is a no-op."""
-        mock_tables = {
+    @pytest.fixture
+    def mock_tables(self):
+        return {
             "table_0": pd.DataFrame({"security_name": ["Bond A"]}),
             "table_1": pd.DataFrame({"security_name": ["Bond B"]}),
         }
+
+    def test_debt_market_returns_dict(self, client, mock_tables):
+        """On cache miss the scraper is called and the result is returned."""
         client._debt_market.fetch.return_value = mock_tables
         result = client.debt_market(cache=True)
         client._debt_market.fetch.assert_called_once()
         assert set(result.keys()) == {"table_0", "table_1"}
+
+    def test_debt_market_cache_hit_skips_scraper(self, client, mock_tables):
+        """Second call with cache=True reuses cached result without fetching."""
+        client._debt_market.fetch.return_value = mock_tables
+        client.debt_market(cache=True)
+        client.debt_market(cache=True)
+        client._debt_market.fetch.assert_called_once()
+
+    def test_debt_market_cache_false_bypasses(self, client, mock_tables):
+        """cache=False always calls the scraper regardless of cache state."""
+        client._debt_market.fetch.return_value = mock_tables
+        client.debt_market(cache=True)
+        client.debt_market(cache=False)
+        assert client._debt_market.fetch.call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -333,13 +350,30 @@ class TestDebtMarket:
 # ---------------------------------------------------------------------------
 
 class TestEligibleScrips:
-    def test_eligible_scrips_returns_dict(self, client):
-        """eligible_scrips() passes through the scraper result; cache flag is a no-op."""
-        mock_tables = {
+    @pytest.fixture
+    def mock_tables(self):
+        return {
             f"table_{i}": pd.DataFrame({"symbol": [f"SYM{i}"]})
             for i in range(9)
         }
+
+    def test_eligible_scrips_returns_dict(self, client, mock_tables):
+        """On cache miss the scraper is called and the result is returned."""
         client._eligible_scrips.fetch.return_value = mock_tables
         result = client.eligible_scrips(cache=True)
         client._eligible_scrips.fetch.assert_called_once()
         assert set(result.keys()) == {f"table_{i}" for i in range(9)}
+
+    def test_eligible_scrips_cache_hit_skips_scraper(self, client, mock_tables):
+        """Second call with cache=True reuses cached result without fetching."""
+        client._eligible_scrips.fetch.return_value = mock_tables
+        client.eligible_scrips(cache=True)
+        client.eligible_scrips(cache=True)
+        client._eligible_scrips.fetch.assert_called_once()
+
+    def test_eligible_scrips_cache_false_bypasses(self, client, mock_tables):
+        """cache=False always calls the scraper regardless of cache state."""
+        client._eligible_scrips.fetch.return_value = mock_tables
+        client.eligible_scrips(cache=True)
+        client.eligible_scrips(cache=False)
+        assert client._eligible_scrips.fetch.call_count == 2

--- a/tests/unit/test_disk_cache.py
+++ b/tests/unit/test_disk_cache.py
@@ -70,6 +70,40 @@ class TestDiskCacheTTL:
         assert cache.get("TODAY") is None
 
 
+class TestDiskCacheDict:
+    @pytest.fixture
+    def tables(self):
+        return {
+            "table_0": pd.DataFrame({"security_name": ["Bond A"], "value": [1.0]}),
+            "table_1": pd.DataFrame({"security_name": ["Bond B"], "value": [2.0]}),
+        }
+
+    def test_dict_miss_returns_none(self, cache):
+        assert cache.get_dict("debt_market_all") is None
+
+    def test_dict_write_then_read(self, cache, tables):
+        cache.set_dict("debt_market_all", tables)
+        result = cache.get_dict("debt_market_all")
+        assert result is not None
+        assert set(result.keys()) == {"table_0", "table_1"}
+        pd.testing.assert_frame_equal(result["table_0"], tables["table_0"])
+        pd.testing.assert_frame_equal(result["table_1"], tables["table_1"])
+
+    def test_dict_partial_hit_returns_none(self, cache, tables):
+        """If any table entry expires, get_dict returns None (full miss)."""
+        cache.set_dict("partial_key", tables, ttl=1)
+        assert cache.get_dict("partial_key") is not None
+        # Manually delete one table entry to simulate partial expiry
+        cache.delete("partial_key__table_1")
+        assert cache.get_dict("partial_key") is None
+
+    def test_dict_ttl_expires(self, cache, tables):
+        cache.set_dict("ttl_key", tables, ttl=1)
+        assert cache.get_dict("ttl_key") is not None
+        time.sleep(1.1)
+        assert cache.get_dict("ttl_key") is None
+
+
 class TestDiskCacheKeyConvention:
     def test_standard_key_format(self, cache, sample_df):
         """Demonstrate the standard caller key convention."""


### PR DESCRIPTION
## Summary

- `DiskCache` gains `get_dict` / `set_dict`: fan-out to per-table parquet entries under a `{key}__manifest` key; partial-hit (manifest present, table expired) is treated as a full miss
- `debt_market()` and `eligible_scrips()` in `PSXClient` now use the standard cache-read-or-fetch pattern with `CACHE_TTL_TODAY` — `cache=False` bypasses as expected
- 4 new `TestDiskCacheDict` tests + 4 new client tests (cache hit / bypass for each method)

## Test plan

- [x] `pytest tests/unit/test_disk_cache.py tests/unit/test_client.py` — 35 tests pass
- [x] `ruff check` — clean

Closes #60