### PR TITLE
feat: Phase 6 — PyPI packaging (0.1.0a1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e ".[dev]"
-          playwright install chromium
 
       - name: Run integration tests
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,60 @@ on:
 permissions: {}
 
 jobs:
+  verify-version:
+    name: Verify tag matches package version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check tag matches pyproject.toml version
+        run: |
+          PKG_VERSION=$(python3 -c "
+import tomllib
+with open('pyproject.toml', 'rb') as f:
+    print(tomllib.load(f)['project']['version'])
+")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          echo "Package version: $PKG_VERSION"
+          echo "Tag version:     $TAG_VERSION"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "ERROR: tag $GITHUB_REF_NAME does not match pyproject.toml version $PKG_VERSION"
+            exit 1
+          fi
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    needs: verify-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run unit tests
+        run: |
+          if [ -d tests/unit ]; then
+            pytest tests/unit/ -v --tb=short
+          else
+            echo "tests/unit/ not yet created - no tests to run"
+          fi
+
   build:
-    name: Build distribution
+    name: Build and verify distribution
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,10 +74,18 @@ jobs:
           python-version: "3.11"
 
       - name: Install build tools
-        run: pip install build
+        run: pip install build twine
 
       - name: Build package
         run: python -m build
+
+      - name: Check distribution metadata
+        run: twine check dist/*
+
+      - name: Smoke install wheel
+        run: |
+          pip install dist/*.whl
+          python -c "import psxdata; print(psxdata.__version__)"
 
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v4
@@ -33,16 +93,36 @@ jobs:
           name: dist
           path: dist/
 
-  publish:
-    name: Publish to PyPI
+  publish-testpypi:
+    name: Publish to TestPyPI
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      id-token: write   # OIDC token for trusted PyPI publish — only this job needs it
+      id-token: write
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/psxdata/
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     environment:
       name: pypi
       url: https://pypi.org/project/psxdata/
-
     steps:
       - name: Download distribution artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -1,0 +1,24 @@
+name: Schema Drift Check
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Every Monday 6am UTC
+  workflow_dispatch:       # Manual trigger
+
+jobs:
+  drift-check:
+    name: Probe PSX endpoints for schema drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run schema drift check
+        run: python tools/probe_endpoints.py --diff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,6 @@ source .venv/bin/activate       # Linux/Mac
 .venv\Scripts\activate          # Windows
 
 pip install -e ".[dev]"
-playwright install chromium     # Required for JS-rendered PSX pages
 ```
 
 Verify your setup:

--- a/psxdata/__init__.py
+++ b/psxdata/__init__.py
@@ -12,7 +12,7 @@ from psxdata.client import (
 )
 from psxdata.scrapers.base import BaseScraper
 
-__version__ = "0.1.0"
+__version__ = "0.1.0a1"
 
 __all__ = [
     "BaseScraper",

--- a/psxdata/scrapers/base.py
+++ b/psxdata/scrapers/base.py
@@ -15,6 +15,7 @@ import time
 from typing import Any
 
 import requests
+
 from psxdata.constants import (
     BASE_URL,
     ENDPOINTS,

--- a/psxdata/scrapers/base.py
+++ b/psxdata/scrapers/base.py
@@ -4,10 +4,7 @@ Scraping mode:
   - requests + BeautifulSoup: via _get() / _post()
 
 All PSX endpoints are accessible via plain HTTP requests to AJAX endpoints.
-Playwright is no longer needed for scraping (see issue #31).
-
-The _playwright_page() method is retained for tooling (e.g. endpoint discovery)
-but is deprecated for scraper use.
+Playwright is not used — all scrapers use requests only.
 
 All Phase 3 scrapers inherit from BaseScraper.
 """
@@ -15,13 +12,9 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Generator
-from contextlib import contextmanager
 from typing import Any
 
 import requests
-from playwright.sync_api import Page, sync_playwright
-
 from psxdata.constants import (
     BASE_URL,
     ENDPOINTS,
@@ -51,10 +44,6 @@ class BaseScraper:
     - Exponential backoff retry (MAX_RETRIES attempts, RETRY_DELAYS seconds)
     - Thread-safe rate limiter (MAX_REQUESTS_PER_SECOND)
 
-    Note:
-        Playwright support is deprecated for scraper use. All PSX endpoints
-        are accessible via plain HTTP AJAX requests. _playwright_page() is
-        retained only for tooling (AJAX endpoint discovery). See issue #31.
     """
 
     def __init__(self) -> None:
@@ -147,26 +136,4 @@ class BaseScraper:
         """POST request to a named PSX endpoint."""
         return self._request("POST", self._build_url(endpoint), data=data, **kwargs)
 
-    @contextmanager
-    def _playwright_page(self) -> Generator[Page, None, None]:
-        """Context manager providing a Playwright Page.
 
-        .. deprecated::
-            All PSX endpoints now have plain HTTP AJAX equivalents.
-            Scrapers should use _get() / _post() instead. This method
-            is retained only for tooling (e.g. AJAX endpoint discovery).
-            See issue #31 for details.
-
-        Usage::
-
-            with self._playwright_page() as page:
-                page.goto(url, wait_until="networkidle")
-                html = page.content()
-        """
-        with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True)
-            page = browser.new_page(extra_http_headers=REQUEST_HEADERS)
-            try:
-                yield page
-            finally:
-                browser.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "psxdata"
-version = "0.1.0"
+version = "0.1.0a1"
 description = "Python library and REST API for Pakistan Stock Exchange (PSX) data"
 readme = "README.md"
 requires-python = ">=3.11"
 keywords = ["psx", "pakistan", "stock", "market", "finance", "data"]
+license = {file = "LICENSE.md"}
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -17,6 +18,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Office/Business :: Financial",
+    "Topic :: Office/Business :: Financial :: Investment",
+    "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
     "requests>=2.28",
@@ -29,7 +34,6 @@ dependencies = [
     "tqdm>=4.64",
     "diskcache>=5.4",
     "pydantic>=2.0",
-    "playwright>=1.40",
 ]
 
 [project.optional-dependencies]
@@ -51,9 +55,14 @@ dev = [
     "types-python-dateutil>=2.8",
 ]
 
+[project.urls]
+Homepage = "https://github.com/mtauha/psxdata"
+Source = "https://github.com/mtauha/psxdata"
+"Bug Tracker" = "https://github.com/mtauha/psxdata/issues"
+
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["psxdata*", "api*"]
+include = ["psxdata*"]
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
## Summary

- Removes deprecated `_playwright_page()` and all playwright traces from the library — `pip install psxdata` no longer pulls browser binaries
- Bumps version to `0.1.0a1`, excludes `api/` from wheel, adds classifiers, project URLs, and explicit license field
- Expands `publish.yml` to a 5-job pipeline: verify-version → test (3.11+3.12) → build+verify → TestPyPI → PyPI (manual approval gate)
- Adds dependabot for pip + GitHub Actions (weekly)
- Adds weekly schema-drift CI check via `probe_endpoints.py --diff`

## Test plan

- [ ] 132 unit tests pass locally
- [ ] `twine check dist/*` passes for wheel and sdist
- [ ] Wheel smoke-install: `import psxdata; psxdata.__version__ == "0.1.0a1"`
- [ ] `api/` excluded from wheel contents
- [ ] No playwright references in `psxdata/`
- [ ] Push `v0.1.0a1` tag to trigger publish pipeline

### Issues Addressed
- Closes #88
- Closes #72
- Closes #74
- Closes #82
- Closes #84
- Part of #10