### PR TITLE
fix: resolve publish.yml YAML parse error and harden workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,13 +16,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Check tag matches pyproject.toml version
         run: |
-          PKG_VERSION=$(python3 -c "
-import tomllib
-with open('pyproject.toml', 'rb') as f:
-    print(tomllib.load(f)['project']['version'])
-")
+          PKG_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           echo "Package version: $PKG_VERSION"
           echo "Tag version:     $TAG_VERSION"
@@ -98,6 +99,7 @@ with open('pyproject.toml', 'rb') as f:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     environment:
       name: testpypi
@@ -119,6 +121,7 @@ with open('pyproject.toml', 'rb') as f:
     needs: publish-testpypi
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     environment:
       name: pypi

--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -5,10 +5,14 @@ on:
     - cron: "0 6 * * 1"  # Every Monday 6am UTC
   workflow_dispatch:       # Manual trigger
 
+permissions: {}
+
 jobs:
   drift-check:
     name: Probe PSX endpoints for schema drift
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- **Root cause:** `publish.yml` had a multiline Python script inside a bash `run:` block where the Python lines (`import tomllib`, etc.) had less indentation than the YAML block scalar's indentation level. YAML terminates a literal block scalar when it encounters a line with fewer leading spaces — so the script was cut off and GitHub Actions rejected the workflow file entirely.
- **Fix:** Rewrote the Python call as a single-line `python3 -c "..."` so all content stays within the YAML block.
- **Also added:** `setup-python@v5` (3.11) to the `verify-version` job to guarantee `tomllib` availability (it is only in stdlib from 3.11+).

## Security hardening

- Added `contents: read` to `publish-testpypi` and `publish-pypi` jobs (previously only `id-token: write` was declared — missing explicit read scope).
- Added `permissions: {}` at workflow level and `contents: read` per-job to `schema-drift.yml` (it had no permission declarations at all).

## Issues Addressed
- Closes #74
- Closes #84