### PR TITLE
fix: correct fixture filename case — historical_ENGRO.html → historical_engro.html

### DIFF
--- a/tests/reliability/test_historical.py
+++ b/tests/reliability/test_historical.py
@@ -11,7 +11,7 @@ from psxdata.scrapers.historical import HistoricalScraper
 
 pytestmark = pytest.mark.reliability
 
-FIXTURE = (Path(__file__).parent.parent / "fixtures" / "historical_ENGRO.html").read_text(encoding="utf-8")
+FIXTURE = (Path(__file__).parent.parent / "fixtures" / "historical_engro.html").read_text(encoding="utf-8")
 
 
 def _mock_response(text: str, status_code: int = 200) -> MagicMock:


### PR DESCRIPTION
## Summary

- Fixes `FileNotFoundError` crashing pytest collection on Linux CI runners
- `tests/fixtures/historical_engro.html` exists on disk (lowercase) but `tests/reliability/test_historical.py:14` referenced `historical_ENGRO.html` (uppercase)
- Windows is case-insensitive so it worked locally; Linux CI is not

## Test plan

- [x] CI integration run passes after merge
- [x] `pytest tests/reliability/test_historical.py -v` passes locally

Closes #109