### PR TITLE
feat: Phase 7 — MkDocs documentation site

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+mkdocs:
+  configuration: mkdocs.yml

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 [![CI](https://github.com/mtauha/psxdata/actions/workflows/ci.yml/badge.svg)](https://github.com/mtauha/psxdata/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/psxdata)](https://pypi.org/project/psxdata/)
+[![Documentation](https://readthedocs.org/projects/psxdata/badge/?version=latest)](https://psxdata.readthedocs.io/)
 [![Python](https://img.shields.io/pypi/pyversions/psxdata)](https://pypi.org/project/psxdata/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+**[Full documentation at psxdata.readthedocs.io](https://psxdata.readthedocs.io/)**
 
 **psxdata** is a Python library for downloading Pakistan Stock Exchange (PSX) data — historical OHLCV prices, real-time quotes, KSE-100 index constituents, sector summaries, fundamentals, debt market instruments, and margin-eligible stocks. Free, open-source, and actively maintained.
 

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,37 @@
+"""psxdata quickstart -- run this script to see psxdata in action.
+
+Requires: pip install psxdata
+"""
+import psxdata
+
+print("=" * 50)
+print("psxdata quickstart")
+print("=" * 50)
+
+# 1. Historical prices
+print("\n1. ENGRO historical prices (last 5 rows)")
+df = psxdata.stocks("ENGRO", start="2024-01-01", end="2024-12-31")
+print(df.tail())
+
+# 2. Live quote
+print("\n2. ENGRO live quote")
+q = psxdata.quote("ENGRO")
+print(q.T)
+
+# 3. KSE-100 tickers
+print("\n3. KSE-100 tickers (first 10)")
+kse100 = psxdata.tickers(index="KSE100")
+print(f"Total: {len(kse100)} stocks")
+print(kse100[:10])
+
+# 4. Sector summary
+print("\n4. Top 5 sectors by market cap")
+sectors = psxdata.sectors()
+print(sectors.sort_values("market_cap_b", ascending=False)[["sector_name", "market_cap_b"]].head())
+
+# 5. Index constituents
+print("\n5. KSE-100 top 5 by index weight")
+idx = psxdata.indices("KSE100")
+print(idx.nlargest(5, "idx_weight")[["symbol", "idx_weight"]])
+
+print("\nDone. See https://psxdata.readthedocs.io for full documentation.")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,53 @@
+site_name: psxdata
+site_description: >
+  Free Python library for Pakistan Stock Exchange (PSX) data --
+  KSE-100 historical prices, live snapshots, sectors, indices, stock screener.
+site_url: https://psxdata.readthedocs.io/
+repo_url: https://github.com/mtauha/psxdata
+repo_name: mtauha/psxdata
+docs_dir: pages
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - content.code.copy
+  palette:
+    - scheme: default
+      primary: green
+      accent: light-green
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_source: true
+            docstring_style: google
+            members_order: source
+
+markdown_extensions:
+  - pymdownx.snippets:
+      base_path: ["."]
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - admonition
+  - tables
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Guides:
+    - Free PSX Data API: guides/free-psx-api.md
+    - Historical Stock Prices: guides/historical-data.md
+    - Stock Screener: guides/stock-screener.md
+    - Sector Analysis: guides/sector-analysis.md
+    - Indices: guides/indices.md
+    - Live Trading Snapshot: guides/realtime-snapshot.md
+  - API Reference:
+    - Client & Core Functions: api/client.md
+    - Exceptions: api/exceptions.md
+  - Changelog: changelog.md
+  - Contributing: contributing.md

--- a/pages/api/client.md
+++ b/pages/api/client.md
@@ -1,0 +1,8 @@
+---
+title: Client & Core Functions
+description: API reference for PSXClient and all psxdata module-level functions.
+---
+
+# Client & Core Functions
+
+Coming soon.

--- a/pages/api/client.md
+++ b/pages/api/client.md
@@ -5,4 +5,36 @@ description: API reference for PSXClient and all psxdata module-level functions.
 
 # Client & Core Functions
 
-Coming soon.
+All public functions are available at the module level — no instantiation needed:
+
+```python
+import psxdata
+
+df = psxdata.stocks("ENGRO")
+```
+
+For advanced use (custom cache directory, multiple clients), instantiate `PSXClient` directly.
+
+## PSXClient
+
+::: psxdata.client.PSXClient
+
+## Module-level functions
+
+These wrap a lazy shared `PSXClient` instance. They are the recommended entry point for most users.
+
+::: psxdata.client.stocks
+
+::: psxdata.client.quote
+
+::: psxdata.client.tickers
+
+::: psxdata.client.indices
+
+::: psxdata.client.sectors
+
+::: psxdata.client.fundamentals
+
+::: psxdata.client.debt_market
+
+::: psxdata.client.eligible_scrips

--- a/pages/api/exceptions.md
+++ b/pages/api/exceptions.md
@@ -1,0 +1,8 @@
+---
+title: Exceptions
+description: psxdata exception hierarchy reference.
+---
+
+# Exceptions
+
+Coming soon.

--- a/pages/api/exceptions.md
+++ b/pages/api/exceptions.md
@@ -5,4 +5,20 @@ description: psxdata exception hierarchy reference.
 
 # Exceptions
 
-Coming soon.
+All psxdata exceptions inherit from `PSXDataError`.
+
+::: psxdata.exceptions
+
+## Catching exceptions
+
+```python
+from psxdata.exceptions import PSXConnectionError, PSXServerError
+import psxdata
+
+try:
+    df = psxdata.stocks("ENGRO")
+except PSXConnectionError:
+    print("Network error — PSX unreachable. Check your connection.")
+except PSXServerError:
+    print("PSX server error — try again later.")
+```

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -1,0 +1,6 @@
+---
+title: Changelog
+description: psxdata release history and version changelog.
+---
+
+Coming soon.

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -3,4 +3,4 @@ title: Changelog
 description: psxdata release history and version changelog.
 ---
 
-Coming soon.
+--8<-- "CHANGELOG.md"

--- a/pages/contributing.md
+++ b/pages/contributing.md
@@ -1,0 +1,6 @@
+---
+title: Contributing
+description: How to contribute to psxdata.
+---
+
+Coming soon.

--- a/pages/contributing.md
+++ b/pages/contributing.md
@@ -3,4 +3,4 @@ title: Contributing
 description: How to contribute to psxdata.
 ---
 
-Coming soon.
+--8<-- "CONTRIBUTING.md"

--- a/pages/getting-started.md
+++ b/pages/getting-started.md
@@ -1,0 +1,8 @@
+---
+title: Getting Started
+description: Install psxdata and fetch your first PSX stock data in under 5 minutes.
+---
+
+# Getting Started
+
+Coming soon.

--- a/pages/getting-started.md
+++ b/pages/getting-started.md
@@ -5,4 +5,66 @@ description: Install psxdata and fetch your first PSX stock data in under 5 minu
 
 # Getting Started
 
-Coming soon.
+## Installation
+
+Requires Python 3.11+.
+
+```bash
+pip install psxdata
+```
+
+To install inside a virtual environment (recommended):
+
+```bash
+python -m venv .venv
+source .venv/bin/activate   # Linux/macOS
+.venv\Scripts\activate      # Windows
+pip install psxdata
+```
+
+## Your first script
+
+Fetch five years of ENGRO historical prices:
+
+```python
+import psxdata
+
+df = psxdata.stocks("ENGRO", start="2020-01-01", end="2024-12-31")
+print(df.shape)       # (rows, 7)
+print(df.dtypes)
+print(df.head())
+```
+
+Expected output:
+
+```
+(1234, 7)
+date         datetime64[ns]
+open                float64
+high                float64
+low                 float64
+close               float64
+volume                int64
+is_anomaly             bool
+dtype: object
+
+        date    open    high     low   close    volume  is_anomaly
+0 2020-01-02  286.90  293.50  285.00  291.00   1200000       False
+...
+```
+
+## Caching
+
+psxdata caches all data to `~/.psxdata/cache/` using parquet format. Historical data (before today) never expires. Today's rows refresh every 15 minutes.
+
+To bypass the cache:
+
+```python
+df = psxdata.stocks("ENGRO", cache=False)
+```
+
+## Next steps
+
+- [Historical Stock Prices guide](guides/historical-data.md) — full walkthrough with pandas analysis
+- [Stock Screener guide](guides/stock-screener.md) — filter all listed stocks
+- [API Reference](api/client.md) — complete function signatures and parameters

--- a/pages/guides/free-psx-api.md
+++ b/pages/guides/free-psx-api.md
@@ -1,0 +1,8 @@
+---
+title: How to Use the Free PSX Data API with Python
+description: Step-by-step guide to downloading free Pakistan Stock Exchange data with the psxdata Python library.
+---
+
+# How to Use the Free PSX Data API with Python
+
+Coming soon.

--- a/pages/guides/free-psx-api.md
+++ b/pages/guides/free-psx-api.md
@@ -5,4 +5,53 @@ description: Step-by-step guide to downloading free Pakistan Stock Exchange data
 
 # How to Use the Free PSX Data API with Python
 
-Coming soon.
+`psxdata` is a free, open-source Python library that gives you programmatic access to Pakistan Stock Exchange (PSX) data — no API key, no subscription, no browser.
+
+## What data is available?
+
+| Data type | Function | What you get |
+|---|---|---|
+| Historical prices | `psxdata.stocks()` | OHLCV for any listed stock, all history |
+| Live snapshot | `psxdata.quote()` | Current price, sector, market cap |
+| Tickers | `psxdata.tickers()` | All PSX symbols, filterable by index |
+| Index data | `psxdata.indices()` | KSE-100 and 17 other indices |
+| Sectors | `psxdata.sectors()` | 37 sector breakdowns |
+| Financials | `psxdata.fundamentals()` | Financial report filing list |
+
+## Install
+
+```bash
+pip install psxdata
+```
+
+## How it works
+
+psxdata scrapes the public PSX website (`dps.psx.com.pk`) using `requests` and `BeautifulSoup`. All endpoints are plain HTTP — no JavaScript rendering, no Selenium, no Playwright. Data is returned as pandas DataFrames.
+
+Results are cached locally at `~/.psxdata/cache/` in parquet format. Historical data never re-downloads. Today's prices refresh every 15 minutes.
+
+## Example: portfolio snapshot
+
+```python
+import psxdata
+import pandas as pd
+
+# Define a simple portfolio
+portfolio = ["ENGRO", "LUCK", "HBL", "OGDC", "PSO"]
+
+# Fetch the latest quote for each stock
+rows = []
+for ticker in portfolio:
+    q = psxdata.quote(ticker)
+    if not q.empty:
+        rows.append(q.iloc[0])
+
+snapshot = pd.DataFrame(rows).reset_index(drop=True)
+print(snapshot[["symbol", "sector", "ldcp"]])
+```
+
+## Next steps
+
+- [Download historical prices](historical-data.md)
+- [Screen PSX stocks](stock-screener.md)
+- [Full API reference](../api/client.md)

--- a/pages/guides/historical-data.md
+++ b/pages/guides/historical-data.md
@@ -1,0 +1,8 @@
+---
+title: Download PSX Historical Stock Prices with Python
+description: Download historical OHLCV prices for any PSX-listed stock using psxdata. Works with pandas out of the box.
+---
+
+# Download PSX Historical Stock Prices with Python
+
+Coming soon.

--- a/pages/guides/historical-data.md
+++ b/pages/guides/historical-data.md
@@ -5,4 +5,85 @@ description: Download historical OHLCV prices for any PSX-listed stock using psx
 
 # Download PSX Historical Stock Prices with Python
 
-Coming soon.
+psxdata returns complete OHLCV history for any PSX-listed stock in a single call.
+
+## Basic usage
+
+```python
+import psxdata
+
+df = psxdata.stocks("ENGRO", start="2024-01-01", end="2024-12-31")
+print(df.head())
+```
+
+Output:
+
+```
+        date    open    high     low   close    volume  is_anomaly
+0 2024-01-02  286.90  293.50  285.00  291.00   1234567       False
+1 2024-01-03  291.00  295.00  289.00  293.50    987654       False
+...
+```
+
+## Date filtering
+
+`start` and `end` accept `str` (ISO format), `datetime.date`, or `None`.
+
+```python
+# Last 90 days
+from datetime import date, timedelta
+
+end = date.today()
+start = end - timedelta(days=90)
+df = psxdata.stocks("LUCK", start=start, end=end)
+```
+
+## Compute returns
+
+```python
+import psxdata
+
+df = psxdata.stocks("HBL", start="2023-01-01")
+df = df.sort_values("date").reset_index(drop=True)
+
+df["daily_return"] = df["close"].pct_change()
+df["cumulative_return"] = (1 + df["daily_return"]).cumprod() - 1
+
+print(df[["date", "close", "daily_return", "cumulative_return"]].tail())
+```
+
+## Save to CSV or Excel
+
+```python
+import psxdata
+
+df = psxdata.stocks("ENGRO", start="2020-01-01")
+df.to_csv("engro_history.csv", index=False)
+df.to_excel("engro_history.xlsx", index=False)
+```
+
+## Fetch multiple stocks
+
+```python
+import psxdata
+import pandas as pd
+
+tickers = ["ENGRO", "LUCK", "HBL"]
+frames = {t: psxdata.stocks(t, start="2024-01-01") for t in tickers}
+
+# Build a close-price matrix
+close = pd.DataFrame({t: df.set_index("date")["close"] for t, df in frames.items()})
+print(close.tail())
+```
+
+## Bypass cache
+
+```python
+# Always fetch fresh from PSX (slower)
+df = psxdata.stocks("ENGRO", cache=False)
+```
+
+## See also
+
+- [`PSXClient.stocks()`](../api/client.md) — full parameter reference
+- [Stock Screener guide](stock-screener.md) — find which stocks to analyse

--- a/pages/guides/indices.md
+++ b/pages/guides/indices.md
@@ -1,0 +1,8 @@
+---
+title: Fetch KSE-100 and PSX Index Data with Python
+description: Download KSE-100, KSE-30, and all PSX index data programmatically using psxdata.
+---
+
+# Fetch KSE-100 and PSX Index Data with Python
+
+Coming soon.

--- a/pages/guides/indices.md
+++ b/pages/guides/indices.md
@@ -5,4 +5,61 @@ description: Download KSE-100, KSE-30, and all PSX index data programmatically u
 
 # Fetch KSE-100 and PSX Index Data with Python
 
-Coming soon.
+`psxdata.indices()` returns constituent data for any of the 18 PSX indices, including index weights and market cap.
+
+## Fetch KSE-100 constituents
+
+```python
+import psxdata
+
+df = psxdata.indices("KSE100")
+print(df.columns.tolist())
+# ['symbol', 'current_index', 'idx_weight', 'idx_point', 'market_cap_m', 'freefloat_m']
+print(df.head())
+```
+
+## Available indices
+
+Pass the index name as a string:
+
+| Index name string | Description |
+| --- | --- |
+| `"KSE100"` | KSE-100 Index |
+| `"KSE30"` | KSE-30 Index |
+| `"KMIALLSHR"` | KMI All Shares Index |
+| `"KMI30"` | KMI-30 Index |
+| `"BKTI"` | Banking Index |
+| `"NITPGE"` | NIT PSX Governance Index |
+
+See `psxdata/constants.py` for the complete list.
+
+## Top 10 by index weight
+
+```python
+import psxdata
+
+df = psxdata.indices("KSE100")
+top10 = df.nlargest(10, "idx_weight")[["symbol", "idx_weight", "market_cap_m"]]
+print(top10)
+```
+
+## Get tickers for an index
+
+To get just the symbol list (cheaper than fetching full constituent data):
+
+```python
+import psxdata
+
+tickers = psxdata.tickers(index="KSE100")
+print(f"{len(tickers)} stocks in KSE-100")
+```
+
+!!! note
+    `tickers(index="KSE100")` and `indices("KSE100")` share the same cache key.
+    Calling both in the same session makes only one network request.
+
+## See also
+
+- [`indices()`](../api/client.md) — parameter reference
+- [`tickers()`](../api/client.md) — symbol-only list by index
+- [Historical Data guide](historical-data.md) — download prices for index constituents

--- a/pages/guides/realtime-snapshot.md
+++ b/pages/guides/realtime-snapshot.md
@@ -1,0 +1,8 @@
+---
+title: Get Live PSX Trading Board Snapshots with Python
+description: Fetch point-in-time live trading board data from PSX using psxdata -- no browser required.
+---
+
+# Get Live PSX Trading Board Snapshots with Python
+
+Coming soon.

--- a/pages/guides/realtime-snapshot.md
+++ b/pages/guides/realtime-snapshot.md
@@ -5,4 +5,70 @@ description: Fetch point-in-time live trading board data from PSX using psxdata 
 
 # Get Live PSX Trading Board Snapshots with Python
 
-Coming soon.
+`psxdata.quote()` returns a live screener snapshot for any PSX-listed stock — current price, sector, market cap, and more. This data is fetched in real time from PSX during market hours.
+
+!!! note
+    PSX does not expose tick-by-tick or minute-bar data via its public website.
+    `quote()` gives you a point-in-time snapshot — suitable for dashboards and
+    portfolio monitors that refresh every few minutes.
+
+## Single stock snapshot
+
+```python
+import psxdata
+
+q = psxdata.quote("ENGRO")
+print(q.T)   # transpose so columns become rows for easier reading
+```
+
+## Build a portfolio monitor
+
+```python
+import psxdata
+import time
+from datetime import datetime
+
+portfolio = ["ENGRO", "LUCK", "HBL", "OGDC"]
+
+while True:
+    print(f"\n--- Snapshot at {datetime.now().strftime('%H:%M:%S')} ---")
+    for ticker in portfolio:
+        q = psxdata.quote(ticker, cache=False)   # cache=False forces a fresh fetch
+        if not q.empty:
+            row = q.iloc[0]
+            print(f"{ticker:8s}  {row['ldcp']}")
+    time.sleep(300)   # wait 5 minutes between polls
+```
+
+!!! warning
+    The PSX screener is a heavy page. Use `cache=False` sparingly — the default
+    15-minute cache means psxdata fetches the screener at most 4 times per hour
+    for all symbols combined, not once per symbol.
+
+## Check if market is open
+
+```python
+from datetime import datetime
+
+def market_open() -> bool:
+    """Returns True if PSX market is currently open (Mon-Fri, 09:15-15:30 PKT)."""
+    now = datetime.utcnow()
+    # PKT is UTC+5
+    pkt_hour = (now.hour + 5) % 24
+    pkt_minute = now.minute
+    pkt_time = pkt_hour * 60 + pkt_minute
+    open_time = 9 * 60 + 15
+    close_time = 15 * 60 + 30
+    return now.weekday() < 5 and open_time <= pkt_time <= close_time
+
+if market_open():
+    q = psxdata.quote("ENGRO", cache=False)
+    print(q)
+else:
+    print("Market is closed.")
+```
+
+## See also
+
+- [`quote()`](../api/client.md) — full parameter reference
+- [Stock Screener guide](stock-screener.md) — screen multiple stocks at once

--- a/pages/guides/sector-analysis.md
+++ b/pages/guides/sector-analysis.md
@@ -1,0 +1,8 @@
+---
+title: Analyse PSX Sector Performance with Python
+description: Fetch sector-wise summary data from PSX and analyse performance trends using pandas.
+---
+
+# Analyse PSX Sector Performance with Python
+
+Coming soon.

--- a/pages/guides/sector-analysis.md
+++ b/pages/guides/sector-analysis.md
@@ -5,4 +5,57 @@ description: Fetch sector-wise summary data from PSX and analyse performance tre
 
 # Analyse PSX Sector Performance with Python
 
-Coming soon.
+`psxdata.sectors()` returns a summary of all 37 PSX sectors including advance/decline counts, turnover, and market capitalisation.
+
+## Fetch sector data
+
+```python
+import psxdata
+
+df = psxdata.sectors()
+print(df.columns.tolist())
+# ['sector_code', 'sector_name', 'advance', 'decline', 'unchanged', 'turnover', 'market_cap_b']
+print(df.shape)
+# (37, 7)
+```
+
+## Top sectors by market cap
+
+```python
+import psxdata
+
+df = psxdata.sectors()
+top10 = df.sort_values("market_cap_b", ascending=False).head(10)
+print(top10[["sector_name", "market_cap_b"]])
+```
+
+## Advance/decline ratio
+
+```python
+import psxdata
+
+df = psxdata.sectors()
+df["ad_ratio"] = df["advance"] / (df["decline"] + 1)  # +1 avoids ZeroDivisionError
+bullish = df[df["ad_ratio"] > 2][["sector_name", "advance", "decline", "ad_ratio"]]
+print(bullish.sort_values("ad_ratio", ascending=False))
+```
+
+## Find stocks in a specific sector
+
+```python
+import psxdata
+import pandas as pd
+
+# Find tickers in a specific sector via the screener
+kse100 = psxdata.tickers(index="KSE100")
+quotes = [psxdata.quote(t).assign(ticker=t) for t in kse100[:20]]
+
+screener = pd.concat(quotes, ignore_index=True)
+cemento = screener[screener["sector"].str.contains("Cement", na=False)]
+print(cemento[["symbol", "sector", "ldcp"]])
+```
+
+## See also
+
+- [`sectors()`](../api/client.md) — parameter reference
+- [Indices guide](indices.md) — work with KSE-100 index data

--- a/pages/guides/stock-screener.md
+++ b/pages/guides/stock-screener.md
@@ -1,0 +1,8 @@
+---
+title: Screen PSX Stocks with Python
+description: Filter and screen all PSX-listed stocks by sector, index, and trading metrics using psxdata.
+---
+
+# Screen PSX Stocks with Python
+
+Coming soon.

--- a/pages/guides/stock-screener.md
+++ b/pages/guides/stock-screener.md
@@ -5,4 +5,61 @@ description: Filter and screen all PSX-listed stocks by sector, index, and tradi
 
 # Screen PSX Stocks with Python
 
-Coming soon.
+psxdata gives you two screening tools: `tickers()` to list symbols by index, and `quote()` to get current price and sector data for any symbol.
+
+## List all KSE-100 tickers
+
+```python
+import psxdata
+
+kse100 = psxdata.tickers(index="KSE100")
+print(f"KSE-100 has {len(kse100)} stocks")
+print(kse100[:10])
+```
+
+## List all PSX symbols
+
+```python
+all_tickers = psxdata.tickers()   # ~1,000 symbols
+print(f"PSX lists {len(all_tickers)} symbols")
+```
+
+## Get a live quote
+
+```python
+import psxdata
+
+q = psxdata.quote("ENGRO")
+print(q.T)   # transpose for easier reading
+```
+
+## Screen all KSE-100 stocks for a metric
+
+```python
+import psxdata
+import pandas as pd
+
+# Fetch quotes for all KSE-100 stocks
+tickers = psxdata.tickers(index="KSE100")
+
+rows = []
+for t in tickers:
+    q = psxdata.quote(t)
+    if not q.empty:
+        rows.append(q.iloc[0])
+
+screen = pd.DataFrame(rows).reset_index(drop=True)
+print(screen.columns.tolist())
+print(screen.head())
+```
+
+!!! note
+    Screener data refreshes every 15 minutes. psxdata caches the full screener
+    and serves all subsequent `quote()` calls from that cache — so screening
+    all 100 stocks costs only one network request.
+
+## See also
+
+- [`tickers()`](../api/client.md) — parameter reference
+- [`quote()`](../api/client.md) — parameter reference
+- [Historical Data guide](historical-data.md) — download prices for screened stocks

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,0 +1,8 @@
+---
+title: psxdata -- Free PSX Data for Python
+description: Free open-source Python library for Pakistan Stock Exchange (PSX) data -- KSE-100 historical prices, live trading board, sectors, indices, stock screener.
+---
+
+# psxdata -- Free KSE-100 & PSX Historical Data for Python
+
+Coming soon.

--- a/pages/index.md
+++ b/pages/index.md
@@ -5,4 +5,64 @@ description: Free open-source Python library for Pakistan Stock Exchange (PSX) d
 
 # psxdata -- Free KSE-100 & PSX Historical Data for Python
 
-Coming soon.
+Open-source Python library to download free PSX stock data — historical prices, live trading board, KSE-100 indices, sector summaries, and more.
+
+```bash
+pip install psxdata
+```
+
+```python
+import psxdata
+
+# Download ENGRO historical prices
+df = psxdata.stocks("ENGRO", start="2024-01-01", end="2024-12-31")
+print(df.head())
+#        date    open    high     low   close   volume
+# 0  2024-01-02  ...     ...     ...    ...      ...
+```
+
+## Features
+
+| Feature | Description |
+| --- | --- |
+| **Historical Data** | OHLCV prices for any PSX-listed stock, all history in one call |
+| **Live Snapshots** | Point-in-time trading board data via screener |
+| **KSE-100 & Indices** | All 18 PSX indices with constituent weights |
+| **Sector Summary** | 37 sector breakdowns with advance/decline counts |
+| **Stock Screener** | Filter all ~1,000 listed symbols |
+| **Disk Cache** | Parquet-backed local cache — no repeated downloads |
+
+## Why psxdata?
+
+- **Free.** No API key. No rate-limit paywall. Scrapes the public PSX website directly.
+- **pandas-native.** Every function returns a `DataFrame` ready for analysis.
+- **No browser required.** Pure `requests` + `BeautifulSoup` — fast and dependency-light.
+- **Cached.** Historical data never re-downloads. Today's data refreshes every 15 minutes.
+
+## Install
+
+Requires Python 3.11+.
+
+```bash
+pip install psxdata
+```
+
+## Quick Example
+
+```python
+import psxdata
+
+# Historical prices
+df = psxdata.stocks("LUCK", start="2023-01-01")
+
+# All KSE-100 tickers
+kse100 = psxdata.tickers(index="KSE100")
+
+# Sector summary
+sectors = psxdata.sectors()
+
+# Index constituents
+kse_df = psxdata.indices("KSE100")
+```
+
+Continue to [Getting Started](getting-started.md) for a full walkthrough.

--- a/psxdata/__init__.py
+++ b/psxdata/__init__.py
@@ -12,7 +12,7 @@ from psxdata.client import (
 )
 from psxdata.scrapers.base import BaseScraper
 
-__version__ = "0.1.0a1"
+__version__ = "0.1.0a2"
 
 __all__ = [
     "BaseScraper",

--- a/psxdata/client.py
+++ b/psxdata/client.py
@@ -433,40 +433,205 @@ def stocks(
     end: date | str | None = None,
     cache: bool = True,
 ) -> pd.DataFrame:
-    """Fetch historical OHLCV data. See :class:`PSXClient.stocks` for full docs."""
+    """Fetch historical OHLCV data for a PSX-listed symbol.
+
+    Convenience wrapper around :class:`PSXClient`. Uses a shared lazy client
+    instance — no instantiation needed.
+
+    Args:
+        symbol: PSX ticker, e.g. ``"ENGRO"``.
+        start: Start date (inclusive). ``None`` means earliest available.
+        end: End date (inclusive). ``None`` means today.
+        cache: If ``False``, bypass cache and always fetch from PSX.
+
+    Returns:
+        DataFrame with columns: date, open, high, low, close, volume, is_anomaly.
+        Empty DataFrame if no data is available for the given range.
+
+    Raises:
+        ValueError: If ``start`` is after ``end``.
+        PSXConnectionError: Network failure after retries.
+        PSXServerError: 5xx after retries.
+
+    Example::
+
+        import psxdata
+        df = psxdata.stocks("ENGRO", start="2024-01-01", end="2024-12-31")
+        print(df.head())
+    """
     return _client().stocks(symbol, start=start, end=end, cache=cache)
 
 
 def quote(symbol: str, cache: bool = True) -> pd.DataFrame:
-    """Fetch screener snapshot for a symbol. See :class:`PSXClient.quote` for full docs."""
+    """Fetch the latest screener snapshot for a symbol.
+
+    The full screener is fetched once and cached for 15 minutes.
+    Successive calls for different symbols reuse the same cached screener.
+
+    Args:
+        symbol: PSX ticker, e.g. ``"ENGRO"``.
+        cache: If ``False``, bypass cache and always fetch the screener.
+
+    Returns:
+        Single-row DataFrame with screener columns (symbol, sector, ldcp, ...).
+        Empty DataFrame if the symbol is not present in the screener.
+
+    Raises:
+        PSXConnectionError: Network failure after retries.
+        PSXServerError: 5xx after retries.
+
+    Example::
+
+        import psxdata
+        q = psxdata.quote("ENGRO")
+        print(q.T)
+    """
     return _client().quote(symbol, cache=cache)
 
 
 def tickers(index: str | None = None, cache: bool = True) -> list[str]:
-    """Return ticker symbols. See :class:`PSXClient.tickers` for full docs."""
+    """Return PSX ticker symbols, optionally filtered to an index.
+
+    Args:
+        index: Index name, e.g. ``"KSE100"``. ``None`` returns all listed
+            symbols. See ``psxdata/constants.py`` for valid index names.
+        cache: If ``False``, bypass cache.
+
+    Returns:
+        List of ticker strings, e.g. ``["ENGRO", "LUCK", ...]``.
+        Empty list if no symbols are found.
+
+    Raises:
+        PSXConnectionError: Network failure after retries.
+        PSXServerError: 5xx after retries.
+        PSXParseError: PSX returned 4xx for the given index name.
+
+    Example::
+
+        import psxdata
+        kse100 = psxdata.tickers(index="KSE100")
+        print(f"KSE-100 has {len(kse100)} stocks")
+    """
     return _client().tickers(index=index, cache=cache)
 
 
 def indices(name: str, cache: bool = True) -> pd.DataFrame:
-    """Fetch index constituents. See :class:`PSXClient.indices` for full docs."""
+    """Fetch constituent data for a PSX index.
+
+    Args:
+        name: Index name, e.g. ``"KSE100"``. See ``psxdata/constants.py``.
+        cache: If ``False``, bypass cache.
+
+    Returns:
+        DataFrame with columns: symbol, current_index, idx_weight,
+        idx_point, market_cap_m, and either freefloat_m or shares_m.
+        Empty DataFrame if PSX returns no data.
+
+    Raises:
+        PSXConnectionError: Network failure after retries.
+        PSXServerError: 5xx after retries.
+        PSXParseError: PSX returned 4xx for the given index name.
+
+    Example::
+
+        import psxdata
+        df = psxdata.indices("KSE100")
+        print(df.nlargest(10, "idx_weight")[["symbol", "idx_weight"]])
+    """
     return _client().indices(name, cache=cache)
 
 
 def sectors(cache: bool = True) -> pd.DataFrame:
-    """Fetch sector summary. See :class:`PSXClient.sectors` for full docs."""
+    """Fetch the PSX sector summary.
+
+    Args:
+        cache: If ``False``, bypass cache.
+
+    Returns:
+        DataFrame with columns: sector_code, sector_name, advance, decline,
+        unchanged, turnover, market_cap_b.
+
+    Raises:
+        PSXConnectionError: Network failure after retries.
+        PSXServerError: 5xx after retries.
+
+    Example::
+
+        import psxdata
+        df = psxdata.sectors()
+        print(df.sort_values("market_cap_b", ascending=False).head())
+    """
     return _client().sectors(cache=cache)
 
 
 def fundamentals(symbol: str | None = None, cache: bool = True) -> pd.DataFrame:
-    """Fetch financial reports list. See :class:`PSXClient.fundamentals` for full docs."""
+    """Fetch the PSX financial reports filing list.
+
+    Args:
+        symbol: If provided, return only filings for this ticker.
+        cache: If ``False``, bypass cache.
+
+    Returns:
+        DataFrame with columns: symbol, year, type, period_ended,
+        posting_date, posting_time, document.
+        Empty DataFrame if outside reporting season.
+
+    Raises:
+        PSXConnectionError: Network failure after retries.
+        PSXServerError: 5xx after retries.
+
+    Example::
+
+        import psxdata
+        df = psxdata.fundamentals("ENGRO")
+        print(df)
+    """
     return _client().fundamentals(symbol=symbol, cache=cache)
 
 
 def debt_market(cache: bool = True) -> dict[str, pd.DataFrame]:
-    """Fetch debt market tables. See :class:`PSXClient.debt_market` for full docs."""
+    """Fetch all PSX debt market instrument tables.
+
+    Args:
+        cache: If ``False``, bypass cache and always fetch from PSX.
+
+    Returns:
+        ``dict`` mapping ``table_0``..``table_3`` to DataFrames.
+        Empty dict if no tables are found.
+
+    Raises:
+        PSXConnectionError: Network failure after retries.
+        PSXServerError: 5xx after retries.
+
+    Example::
+
+        import psxdata
+        tables = psxdata.debt_market()
+        for key, df in tables.items():
+            print(key, df.shape)
+    """
     return _client().debt_market(cache=cache)
 
 
 def eligible_scrips(cache: bool = True) -> dict[str, pd.DataFrame]:
-    """Fetch eligible scrip tables. See :class:`PSXClient.eligible_scrips` for full docs."""
+    """Fetch all PSX margin-trading eligible scrip tables.
+
+    Args:
+        cache: If ``False``, bypass cache and always fetch from PSX.
+
+    Returns:
+        ``dict`` mapping ``table_0``..``table_8`` to DataFrames.
+        Empty dict if no tables are found.
+
+    Raises:
+        PSXConnectionError: Network failure after retries.
+        PSXServerError: 5xx after retries.
+
+    Example::
+
+        import psxdata
+        tables = psxdata.eligible_scrips()
+        for key, df in tables.items():
+            print(key, df.shape)
+    """
     return _client().eligible_scrips(cache=cache)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,17 @@ dev = [
     "types-requests>=2.28",
     "types-python-dateutil>=2.8",
 ]
+docs = [
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.25",
+]
 
 [project.urls]
 Homepage = "https://github.com/mtauha/psxdata"
 Source = "https://github.com/mtauha/psxdata"
 "Bug Tracker" = "https://github.com/mtauha/psxdata/issues"
 Changelog = "https://github.com/mtauha/psxdata/blob/main/CHANGELOG.md"
+Documentation = "https://psxdata.readthedocs.io/"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

- Adds MkDocs + Material theme documentation site, built and hosted free on Read the Docs at `https://psxdata.readthedocs.io`
- 12 pages: home (SEO-optimised), getting started, 6 tutorial guides, 2 API reference pages, changelog, contributing
- API reference auto-generated from docstrings via `mkdocstrings[python]`
- `pages/` as `docs_dir` (avoids collision with gitignored `docs/` agent dir)
- `.readthedocs.yaml` v2 config for RTD free-tier build
- `examples/quickstart.py` runnable demo script
- Expanded all 8 module-level function docstrings for clean API reference rendering

## What still needs to happen after merge

1. **Connect repo to Read the Docs** — go to `https://readthedocs.org/dashboard/import/`, import `mtauha/psxdata`, set default branch to `main`, trigger first build
2. The RTD badge in README will show "unknown" until the first build succeeds — it turns green automatically

## Test plan

- [x] `mkdocs build` runs with zero errors locally (Python 3.13 + mkdocs 1.6.1)
- [x] All 12 nav pages resolve without broken-reference errors
- [x] pymdownx.snippets includes CHANGELOG.md and CONTRIBUTING.md correctly
- [x] `mkdocstrings` directives render PSXClient and all 8 module-level functions
- [x] RTD build config validated (`.readthedocs.yaml` v2 format)
- [x] `examples/quickstart.py` runs without import errors

## Closes

- Closes #85
- Closes #94
- Closes #11
- Partial #76
