### PR TITLE
feat: standardize API response envelope (schemas, exception handlers, GET /health)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -195,7 +195,9 @@ GET  /debt-market
 GET  /eligible-scrips
 ```
 
-All responses: `{"data": ..., "meta": {"timestamp": ..., "cached": bool}}`
+All responses: `{"data": ..., "meta": {"timestamp": ..., "cached": bool}}` — list responses also include `"count": N` in meta.
+
+Errors: `{"error": {"status": 404, "code": "not_found", "message": "..."}}`
 
 Rate limit: 60 req/min per IP via `slowapi`. CORS: all origins. No auth required.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,10 +142,15 @@ Never add FastAPI imports to `tests/unit/` outside of `tests/unit/api/` — thos
    ```
 3. Declare `tags=` on the `APIRouter` for docs grouping
 4. Use a fully-typed `response_model` — `dict[str, str]` not `dict`
-5. All responses must follow this envelope:
-   ```python
-   {"data": ..., "meta": {"timestamp": ..., "cached": bool}}
-   ```
+5. All responses must follow the approved envelope spec:
+   - List endpoint:   `{"data": [...], "meta": {"timestamp": "...", "cached": bool, "count": N}}`
+   - Single-item:    `{"data": {...}, "meta": {"timestamp": "...", "cached": bool}}`
+   - Named tables:   `{"data": {"table_0": [...], ...}, "meta": {"timestamp": "...", "cached": bool}}`
+   - Error:          `{"error": {"status": 404, "code": "not_found", "message": "..."}}`
+
+   Use `MetaSingle` / `MetaList` from `api/schemas.py`. Never construct meta dicts by hand.
+   Error codes: `bad_request` (400/422), `not_found` (404), `rate_limited` (429),
+                `psx_unavailable` (503), `internal_error` (500).
 6. Map HTTP errors explicitly:
    - `404` — unknown symbol or resource not found
    - `503` — PSX unreachable or library raised `PSXUnavailableError`

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Existing solutions for PSX data tend to hardcode date formats and column positio
 | `GET /debt-market` | Debt instruments |
 | `GET /eligible-scrips` | Margin eligible stocks |
 
-All responses: `{"data": ..., "meta": {"timestamp": "...", "cached": bool}}`
+All responses: `{"data": ..., "meta": {"timestamp": "...", "cached": bool}}` — list responses also include `"count": N` in meta.
+
+Errors: `{"error": {"status": 404, "code": "not_found", "message": "..."}}`
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -4,8 +4,11 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from .routers import router_registry
+from psxdata.exceptions import InvalidSymbolError, PSXUnavailableError
+
+from api.routers import router_registry
 
 
 @asynccontextmanager
@@ -26,21 +29,64 @@ app.add_middleware(
 )
 
 
+_ERROR_CODES: dict[int, str] = {
+    400: "bad_request",
+    404: "not_found",
+    422: "bad_request",
+    429: "rate_limited",
+    503: "psx_unavailable",
+    500: "internal_error",
+}
+
+
+@app.exception_handler(PSXUnavailableError)
+async def psx_unavailable_handler(request: Request, exc: PSXUnavailableError) -> JSONResponse:
+    return JSONResponse(
+        status_code=503,
+        content={"error": {"status": 503, "code": "psx_unavailable", "message": str(exc)}},
+    )
+
+
+@app.exception_handler(InvalidSymbolError)
+async def invalid_symbol_handler(request: Request, exc: InvalidSymbolError) -> JSONResponse:
+    return JSONResponse(
+        status_code=404,
+        content={"error": {"status": 404, "code": "not_found", "message": str(exc)}},
+    )
+
+
+@app.exception_handler(StarletteHTTPException)
 @app.exception_handler(HTTPException)
 async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
-    return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+    code = _ERROR_CODES.get(exc.status_code, "internal_error")
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": {"status": exc.status_code, "code": code, "message": str(exc.detail)}},
+    )
 
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
-    return JSONResponse(status_code=422, content={"detail": exc.errors()})
+    parts = []
+    for e in exc.errors():
+        loc = " -> ".join(str(l) for l in e.get("loc", []) if l != "body")
+        msg = e.get("msg", "invalid value")
+        parts.append(f"{loc}: {msg}" if loc else msg)
+    message = "; ".join(parts) if parts else "invalid input"
+    return JSONResponse(
+        status_code=422,
+        content={"error": {"status": 422, "code": "bad_request", "message": message}},
+    )
 
 
 @app.exception_handler(Exception)
 async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
-    return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
+    return JSONResponse(
+        status_code=500,
+        content={"error": {"status": 500, "code": "internal_error", "message": "Internal Server Error"}},
+    )
 
 
 for router in router_registry:

--- a/api/main.py
+++ b/api/main.py
@@ -1,18 +1,18 @@
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from psxdata.exceptions import InvalidSymbolError, PSXUnavailableError
-
 from api.routers import router_registry
+from psxdata.exceptions import InvalidSymbolError, PSXUnavailableError
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    """Manage application lifespan — startup and shutdown events."""
     # TODO: initialise cache / Redis on startup, close on shutdown.
     yield
 
@@ -43,7 +43,7 @@ _ERROR_CODES: dict[int, str] = {
 async def psx_unavailable_handler(request: Request, exc: PSXUnavailableError) -> JSONResponse:
     return JSONResponse(
         status_code=503,
-        content={"error": {"status": 503, "code": "psx_unavailable", "message": str(exc)}},
+        content={"error": {"status": 503, "code": _ERROR_CODES[503], "message": str(exc)}},
     )
 
 
@@ -51,13 +51,12 @@ async def psx_unavailable_handler(request: Request, exc: PSXUnavailableError) ->
 async def invalid_symbol_handler(request: Request, exc: InvalidSymbolError) -> JSONResponse:
     return JSONResponse(
         status_code=404,
-        content={"error": {"status": 404, "code": "not_found", "message": str(exc)}},
+        content={"error": {"status": 404, "code": _ERROR_CODES[404], "message": str(exc)}},
     )
 
 
 @app.exception_handler(StarletteHTTPException)
-@app.exception_handler(HTTPException)
-async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
     code = _ERROR_CODES.get(exc.status_code, "internal_error")
     return JSONResponse(
         status_code=exc.status_code,
@@ -71,7 +70,7 @@ async def validation_exception_handler(
 ) -> JSONResponse:
     parts = []
     for e in exc.errors():
-        loc = " -> ".join(str(l) for l in e.get("loc", []) if l != "body")
+        loc = " -> ".join(str(part) for part in e.get("loc", []) if part != "body")
         msg = e.get("msg", "invalid value")
         parts.append(f"{loc}: {msg}" if loc else msg)
     message = "; ".join(parts) if parts else "invalid input"
@@ -85,7 +84,7 @@ async def validation_exception_handler(
 async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     return JSONResponse(
         status_code=500,
-        content={"error": {"status": 500, "code": "internal_error", "message": "Internal Server Error"}},
+        content={"error": {"status": 500, "code": "internal_error", "message": "Internal Server Error"}},  # noqa: E501
     )
 
 

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -1,4 +1,5 @@
-# Skeleton: append routers here as they are added.
 from fastapi import APIRouter
 
-router_registry: list[APIRouter] = []
+from api.routers.health import router as health_router
+
+router_registry: list[APIRouter] = [health_router]

--- a/api/routers/health.py
+++ b/api/routers/health.py
@@ -1,0 +1,22 @@
+"""Health check router — GET /health."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter
+
+from api.schemas import HealthData, HealthResponse, MetaSingle
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health", response_model=HealthResponse)
+def health() -> HealthResponse:
+    """Return API liveness status."""
+    return HealthResponse(
+        data=HealthData(status="ok"),
+        meta=MetaSingle(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            cached=False,
+        ),
+    )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,46 @@
+"""Shared Pydantic models for psxdata API response envelopes."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class MetaSingle(BaseModel):
+    """Metadata block for single-item responses."""
+
+    timestamp: str
+    cached: bool
+
+
+class MetaList(BaseModel):
+    """Metadata block for list responses. Always includes count."""
+
+    timestamp: str
+    cached: bool
+    count: int
+
+
+class ErrorDetail(BaseModel):
+    """Structured error payload."""
+
+    status: int
+    code: str
+    message: str
+
+
+class ErrorEnvelope(BaseModel):
+    """Top-level error response wrapper."""
+
+    error: ErrorDetail
+
+
+class HealthData(BaseModel):
+    """Data payload for GET /health."""
+
+    status: str
+
+
+class HealthResponse(BaseModel):
+    """Typed response model for GET /health."""
+
+    data: HealthData
+    meta: MetaSingle

--- a/tests/unit/api/test_error_envelope.py
+++ b/tests/unit/api/test_error_envelope.py
@@ -1,8 +1,25 @@
 """Tests that all HTTP errors return the standardized error envelope."""
 import pytest
 from fastapi.testclient import TestClient
+from psxdata.exceptions import InvalidSymbolError, PSXUnavailableError
 
 from api.main import app
+
+# Register sentinel routes at module level to avoid mutating `app` inside test bodies.
+# These routes exist only to trigger specific exception types for testing.
+@app.get("/__test_500")
+def _boom():
+    raise Exception("deliberate")
+
+
+@app.get("/__test_503")
+def _psx_down():
+    raise PSXUnavailableError("PSX server unreachable")
+
+
+@app.get("/__test_404_symbol")
+def _bad_symbol():
+    raise InvalidSymbolError("FAKESYM not found on PSX")
 
 
 @pytest.fixture
@@ -27,10 +44,6 @@ def test_error_envelope_has_no_detail_key(client: TestClient) -> None:
 
 
 def test_500_uses_error_envelope(client: TestClient) -> None:
-    @app.get("/__test_500")
-    def boom():
-        raise Exception("deliberate")
-
     resp = client.get("/__test_500")
     assert resp.status_code == 500
     body = resp.json()
@@ -39,12 +52,6 @@ def test_500_uses_error_envelope(client: TestClient) -> None:
 
 
 def test_psx_unavailable_maps_to_503(client: TestClient) -> None:
-    from psxdata.exceptions import PSXUnavailableError
-
-    @app.get("/__test_503")
-    def psx_down():
-        raise PSXUnavailableError("PSX server unreachable")
-
     resp = client.get("/__test_503")
     assert resp.status_code == 503
     body = resp.json()
@@ -54,12 +61,6 @@ def test_psx_unavailable_maps_to_503(client: TestClient) -> None:
 
 
 def test_invalid_symbol_maps_to_404(client: TestClient) -> None:
-    from psxdata.exceptions import InvalidSymbolError
-
-    @app.get("/__test_404_symbol")
-    def bad_symbol():
-        raise InvalidSymbolError("FAKESYM not found on PSX")
-
     resp = client.get("/__test_404_symbol")
     assert resp.status_code == 404
     body = resp.json()

--- a/tests/unit/api/test_error_envelope.py
+++ b/tests/unit/api/test_error_envelope.py
@@ -1,0 +1,67 @@
+"""Tests that all HTTP errors return the standardized error envelope."""
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_404_uses_error_envelope(client: TestClient) -> None:
+    resp = client.get("/nonexistent-route-xyz")
+    assert resp.status_code == 404
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["status"] == 404
+    assert body["error"]["code"] == "not_found"
+    assert "message" in body["error"]
+
+
+def test_error_envelope_has_no_detail_key(client: TestClient) -> None:
+    resp = client.get("/nonexistent-route-xyz")
+    body = resp.json()
+    assert "detail" not in body
+
+
+def test_500_uses_error_envelope(client: TestClient) -> None:
+    @app.get("/__test_500")
+    def boom():
+        raise Exception("deliberate")
+
+    resp = client.get("/__test_500")
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["error"]["status"] == 500
+    assert body["error"]["code"] == "internal_error"
+
+
+def test_psx_unavailable_maps_to_503(client: TestClient) -> None:
+    from psxdata.exceptions import PSXUnavailableError
+
+    @app.get("/__test_503")
+    def psx_down():
+        raise PSXUnavailableError("PSX server unreachable")
+
+    resp = client.get("/__test_503")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["error"]["status"] == 503
+    assert body["error"]["code"] == "psx_unavailable"
+    assert "PSX server unreachable" in body["error"]["message"]
+
+
+def test_invalid_symbol_maps_to_404(client: TestClient) -> None:
+    from psxdata.exceptions import InvalidSymbolError
+
+    @app.get("/__test_404_symbol")
+    def bad_symbol():
+        raise InvalidSymbolError("FAKESYM not found on PSX")
+
+    resp = client.get("/__test_404_symbol")
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["error"]["status"] == 404
+    assert body["error"]["code"] == "not_found"

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -1,0 +1,38 @@
+"""Unit tests for GET /health."""
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_health_returns_200(client: TestClient) -> None:
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+def test_health_data_shape(client: TestClient) -> None:
+    body = client.get("/health").json()
+    assert body["data"] == {"status": "ok"}
+
+
+def test_health_meta_shape(client: TestClient) -> None:
+    meta = client.get("/health").json()["meta"]
+    assert "timestamp" in meta
+    assert "cached" in meta
+    assert meta["cached"] is False
+
+
+def test_health_meta_has_no_count(client: TestClient) -> None:
+    meta = client.get("/health").json()["meta"]
+    assert "count" not in meta
+
+
+def test_health_timestamp_is_iso8601(client: TestClient) -> None:
+    from datetime import datetime
+    ts = client.get("/health").json()["meta"]["timestamp"]
+    datetime.fromisoformat(ts)

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -1,4 +1,6 @@
 """Unit tests for GET /health."""
+from datetime import datetime
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -33,6 +35,5 @@ def test_health_meta_has_no_count(client: TestClient) -> None:
 
 
 def test_health_timestamp_is_iso8601(client: TestClient) -> None:
-    from datetime import datetime
     ts = client.get("/health").json()["meta"]["timestamp"]
     datetime.fromisoformat(ts)

--- a/tests/unit/api/test_schemas.py
+++ b/tests/unit/api/test_schemas.py
@@ -1,0 +1,55 @@
+"""Unit tests for api/schemas.py response envelope models."""
+from api.schemas import (
+    ErrorDetail,
+    ErrorEnvelope,
+    HealthData,
+    HealthResponse,
+    MetaList,
+    MetaSingle,
+)
+
+
+def test_meta_single_fields() -> None:
+    m = MetaSingle(timestamp="2026-04-21T12:00:00Z", cached=False)
+    assert m.timestamp == "2026-04-21T12:00:00Z"
+    assert m.cached is False
+
+
+def test_meta_list_fields() -> None:
+    m = MetaList(timestamp="2026-04-21T12:00:00Z", cached=True, count=42)
+    assert m.count == 42
+    assert m.cached is True
+
+
+def test_error_detail_fields() -> None:
+    e = ErrorDetail(status=404, code="not_found", message="Symbol XYZ not found")
+    assert e.status == 404
+    assert e.code == "not_found"
+    assert e.message == "Symbol XYZ not found"
+
+
+def test_error_envelope_nests_detail() -> None:
+    detail = ErrorDetail(status=503, code="psx_unavailable", message="PSX unreachable")
+    env = ErrorEnvelope(error=detail)
+    assert env.error.status == 503
+
+
+def test_meta_single_model_dump() -> None:
+    m = MetaSingle(timestamp="2026-04-21T12:00:00Z", cached=False)
+    d = m.model_dump()
+    assert set(d.keys()) == {"timestamp", "cached"}
+
+
+def test_meta_list_model_dump() -> None:
+    m = MetaList(timestamp="2026-04-21T12:00:00Z", cached=False, count=10)
+    d = m.model_dump()
+    assert set(d.keys()) == {"timestamp", "cached", "count"}
+
+
+def test_health_response_shape() -> None:
+    resp = HealthResponse(
+        data=HealthData(status="ok"),
+        meta=MetaSingle(timestamp="2026-04-21T12:00:00Z", cached=False),
+    )
+    assert resp.data.status == "ok"
+    assert resp.meta.cached is False


### PR DESCRIPTION
## Summary

- Adds `api/schemas.py` with six Pydantic models: `MetaSingle`, `MetaList`, `ErrorDetail`, `ErrorEnvelope`, `HealthData`, `HealthResponse`
- Replaces ad-hoc exception handlers in `api/main.py` with five spec-compliant handlers — including dedicated handlers for `PSXUnavailableError` (503) and `InvalidSymbolError` (404)
- Adds `GET /health` as the first route using the typed envelope (`response_model=HealthResponse`)
- Updates `README.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md` with finalized response spec rules

Closes #127
Closes #67

## Response spec (approved)

- List: `{"data": [...], "meta": {"timestamp": "...", "cached": bool, "count": N}}`
- Single-item: `{"data": {...}, "meta": {"timestamp": "...", "cached": bool}}`
- Named tables: `{"data": {"table_0": [...], ...}, "meta": {...}}`
- Error: `{"error": {"status": 404, "code": "not_found", "message": "..."}}`

## Test plan

- [x] `pytest tests/unit/api/ -v` — 17 passed
- [x] `ruff check api/` — clean