### PR TITLE
Fix: Update dependency installation to include 'api' extras

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e ".[dev]"
+          pip install -e ".[dev,api]"
 
       - name: Run integration tests
         run: |


### PR DESCRIPTION
Integration run was failing because 'api' dependencies were not included in integration tests pipeline. Fixed

## Summary

This PR introduces the fix for failing integration tests workflow that run every day at midnight.

## Related Issue

- Closes #129 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Infrastructure / CI

## Testing Done

- [x] `pytest tests/unit/ -v` passes
- [x] `pytest -m reliability -v` passes
- [x] `pytest -m integration -v` passes locally (required for scraper changes)
- [x] Manually tested against live PSX endpoint (required for scraper changes)

## Checklist

- [ ] Type hints on all new public functions
- [ ] Docstrings on all new public functions
- [ ] No hardcoded date formats (use `parse_date_safely()`)
- [ ] No fixed column position assumptions (map by `<th>` name)
- [ ] `ruff check psxdata/ api/` passes
- [ ] `mypy psxdata/ api/` passes
- [ ] `CHANGELOG.md` updated (if breaking change or new user-facing feature)
- [ ] New HTML fixture captured if a new PSX endpoint interaction was added
